### PR TITLE
Feature/object literals

### DIFF
--- a/Examples/Application-Configuration.yini
+++ b/Examples/Application-Configuration.yini
@@ -1,0 +1,30 @@
+^ Application
+name         = "MyApp"
+version      = "2.4.1"
+
+# A list of enabled features
+features     = ["login", "search", "notifications"]
+
+# Database connection settings as an inline object.
+database     = {
+    host         = "db.example.com",
+    port         = 5432,
+    username     = "dbuser",
+    password     = "s3cr3t",
+    # Nested “options” object inside "database".
+    options      = {
+        ssl            = true,
+        max_retries    = 5,
+        timeout_secs   = 30,
+    },
+}
+
+# Supported locales as a simple list.
+supportedLocales = [
+    "en",
+    "fr",
+    "de",
+    "es",
+    "sv",
+    "fi",
+]

--- a/Examples/Deeply-Nested-Sections.yini
+++ b/Examples/Deeply-Nested-Sections.yini
@@ -1,0 +1,29 @@
+/*
+  Nesting level respected, no missing intermediary levels.
+
+  Using caret shorthand for deeper nesting.
+*/
+
+^ Root                             # level 1
+rootKey = "rootValue"
+
+^^ Level2                          # level 2
+level2Key = 42
+
+^^^ Level3                         # level 3
+level3Key = true
+
+^^^^ Level4                        # level 4
+level4Key = null
+
+^^^^^ Level5                       # level 5
+level5Key = "hello"
+
+^^^^^^ Level6                      # level 6
+level6Key = [1, 2, 3]
+
+^7 Level7Shorthand                 # level 7 (shorthand)
+level7Key = "deepValue"
+
+^8 Level8Shorthand                 # level 8 (shorthand)
+level8Key = 3.14159

--- a/Examples/Nested-Objects.yini
+++ b/Examples/Nested-Objects.yini
@@ -1,0 +1,23 @@
+/*
+  Nesting level respected, no missing intermediary levels.
+
+  - database is treated as a single "object value."
+  - Inside it, host, port, username, password, and options are all keys with their own values.
+*/
+
+^ Application
+
+name     = "MyApp"
+version  = "1.2.3"
+database = {
+    host     = "db.example.com",
+    port     = 5432,
+    username = "dbuser",
+    password = "s3cr3t",
+    options  = {
+        ssl        = true,
+        maxRetries = 5,
+    },
+}
+
+features = ["login", "search", "notifications"]

--- a/Examples/Triple-Quoted-Strings.yini
+++ b/Examples/Triple-Quoted-Strings.yini
@@ -7,3 +7,12 @@ three lines."""
 test2 = """He said, "hello" and left."""
 
 test3 = """You can use "" double quotes inside."""
+
+test4 = C"""\t He said,
+\t "hello" and left.
+"""
+
+test5 = C"""\t He said,\n
+\t "hello" and\n
+\t left.\n
+"""

--- a/Examples/User-Role-Definitions.yini
+++ b/Examples/User-Role-Definitions.yini
@@ -1,0 +1,45 @@
+^ Users
+# A list of user-objects, each with its own fields.
+users = [
+    {
+        id       = 1001,
+        name     = "Alice",
+        email    = "alice@example.org",
+        role     = "admin",
+        preferences = {
+            theme       = "dark",
+            notifications = ["email", "sms"],
+        },
+    },
+    {
+        id       = 1002,
+        name     = "Bob",
+        email    = "bob@example.org",
+        role     = "editor",
+        preferences = {
+            theme       = "light",
+            notifications = ["email"],
+        },
+    },
+    {
+        id       = 1003,
+        name     = "Charlie",
+        email    = "charlie@example.org",
+        role     = "viewer",
+        preferences = {
+            theme       = "light",
+            notifications = [],
+        },
+    },
+]
+
+# A top-level object defining roles and their permissions.
+roles = {
+    admin  = ["create", "read", "update", "delete"],
+    editor = ["read", "update"],
+    viewer = ["read"],
+}
+
+# A separate list: system-wide default tags
+defaultTags = ["new-user", "trial", "beta"]
+

--- a/Grammar-ANTLR4/Test-samples/Lenient-mode/Valid/Nested-Objects.yini
+++ b/Grammar-ANTLR4/Test-samples/Lenient-mode/Valid/Nested-Objects.yini
@@ -1,0 +1,12 @@
+^cacheSettings
+
+cache = {
+    enabled = true,
+    settings = {
+        ttl   = 600,
+        clean = {
+            interval = 60,
+            force    = false,
+        },
+    },
+}

--- a/Grammar-ANTLR4/YiniLexer.g4
+++ b/Grammar-ANTLR4/YiniLexer.g4
@@ -25,7 +25,7 @@ fragment EBD: ('0' | '1') ('0' | '1') ('0' | '1');
 // COMMENT: BLOCK_COMMENT | LINE_COMMENT;
 
 //SECTION_HEAD: HASH+ [ \t]+ WS* IDENT NL+;
-SECTION_HEAD: SECTION_MARKER [ \t]* WS* IDENT NL+;
+SECTION_HEAD: [ \t]* SECTION_MARKER [ \t]* WS* IDENT NL+;
 
 // Section markers: '^', '~', '§', '€'.
 // – Up to six repeated markers are allowed (the parser must enforce the ≤ 6 rule).

--- a/Grammar-ANTLR4/YiniLexer.g4
+++ b/Grammar-ANTLR4/YiniLexer.g4
@@ -172,8 +172,10 @@ SINGLE_OR_DOUBLE:
  * parser catch it so you can give a more precise error message. 
 */
 R_AND_C_STRING:
-	[RrCc]? '\'' ~['\r\n]* '\''
-	| [RrCc]? '"'	 ~["\r\n]* '"';
+	// [RrCc]? '\'' ~['\r\n]* '\''
+	// | [RrCc]? '"'	 ~["\r\n]* '"';
+	[RrCc]? '\'' 	('\\\'' | ~['\r\n])* '\''
+	| [RrCc]? '"'	('\\"' | ~["\r\n])* '"';
 
 
 // Hyper string literal.

--- a/Grammar-ANTLR4/YiniLexer.g4
+++ b/Grammar-ANTLR4/YiniLexer.g4
@@ -20,6 +20,13 @@
 
 lexer grammar YiniLexer;
 
+/*
+ DISABLE_LINE:
+ Skip lines starting with `--`.
+ NOTE: Must at very top of lexer rules.
+ */
+DISABLE_LINE: ('--' ~[\r\n]*) -> skip;
+
 fragment EBD: ('0' | '1') ('0' | '1') ('0' | '1');
 
 // COMMENT: BLOCK_COMMENT | LINE_COMMENT;
@@ -217,11 +224,14 @@ SINGLE_NL: ('\r' '\n'? | '\n');
 WS: [ \t]+ -> skip;
 
 /*
- DISABLE_LINE:
- Skip lines starting with `--`.
+ BLOCK_COMMENT:
+ Can appear anywhere, spanning multiple lines.
+ Remains in input, but hidden
+ (doesn't interfere with parsing).
  */
-DISABLE_LINE: ('--' ~[\r\n]*) -> skip;
-
+BLOCK_COMMENT:
+	'/*' .*? '*/' -> channel(HIDDEN); // Block AKA Multi-line comment.
+	
 COMMENT: LINE_COMMENT | INLINE_COMMENT | BLOCK_COMMENT;
 /*
  FULL_LINE_COMMENT:
@@ -235,12 +245,3 @@ LINE_COMMENT: (';' ~[\r\n]*) -> channel(HIDDEN);
  Remains in input, but hidden (doesn't interfere with parsing).
  */
 INLINE_COMMENT: ('//' | '#' [ \t]+) ~[\r\n]* -> channel(HIDDEN);
-
-/*
- BLOCK_COMMENT:
- Can appear anywhere, spanning multiple lines.
- Remains in input, but hidden
- (doesn't interfere with parsing).
- */
-BLOCK_COMMENT:
-	'/*' .*? '*/' -> channel(HIDDEN); // Block AKA Multi-line comment.

--- a/Grammar-ANTLR4/YiniLexer.g4
+++ b/Grammar-ANTLR4/YiniLexer.g4
@@ -20,12 +20,19 @@
 
 lexer grammar YiniLexer;
 
+/*
+ DISABLE_LINE:
+ Skip lines starting with `--`.
+ NOTE: Must at very top of lexer rules.
+ */
+DISABLE_LINE: ('--' ~[\r\n]*) -> skip;
+
 fragment EBD: ('0' | '1') ('0' | '1') ('0' | '1');
 
 // COMMENT: BLOCK_COMMENT | LINE_COMMENT;
 
 //SECTION_HEAD: HASH+ [ \t]+ WS* IDENT NL+;
-SECTION_HEAD: SECTION_MARKER [ \t]* WS* IDENT NL+;
+SECTION_HEAD: [ \t]* SECTION_MARKER [ \t]* WS* IDENT NL+;
 
 // Section markers: '^', '~', '§', '€'.
 // – Up to six repeated markers are allowed (the parser must enforce the ≤ 6 rule).
@@ -67,6 +74,8 @@ COMMA: ',';
 COLON: ':';
 OB: '['; // Opening Bracket.
 CB: ']'; // Closing Bracket.
+OC: '{'; // Opening Curly Brace.
+CC: '}'; // Closing Curly Brace.
 PLUS: '+';
 DOLLAR: '$';
 // ASTERIX: '*';
@@ -86,6 +95,7 @@ NULL options {
 	caseInsensitive = true;
 }: 'null';
 
+EMPTY_OBJECT: '{' '}';
 EMPTY_LIST: '[' ']';
 
 SHEBANG: '#!' ~[\n\r\b\f\t]* NL;
@@ -214,11 +224,14 @@ SINGLE_NL: ('\r' '\n'? | '\n');
 WS: [ \t]+ -> skip;
 
 /*
- DISABLE_LINE:
- Skip lines starting with `--`.
+ BLOCK_COMMENT:
+ Can appear anywhere, spanning multiple lines.
+ Remains in input, but hidden
+ (doesn't interfere with parsing).
  */
-DISABLE_LINE: ('--' ~[\r\n]*) -> skip;
-
+BLOCK_COMMENT:
+	'/*' .*? '*/' -> channel(HIDDEN); // Block AKA Multi-line comment.
+	
 COMMENT: LINE_COMMENT | INLINE_COMMENT | BLOCK_COMMENT;
 /*
  FULL_LINE_COMMENT:
@@ -232,12 +245,3 @@ LINE_COMMENT: (';' ~[\r\n]*) -> channel(HIDDEN);
  Remains in input, but hidden (doesn't interfere with parsing).
  */
 INLINE_COMMENT: ('//' | '#' [ \t]+) ~[\r\n]* -> channel(HIDDEN);
-
-/*
- BLOCK_COMMENT:
- Can appear anywhere, spanning multiple lines.
- Remains in input, but hidden
- (doesn't interfere with parsing).
- */
-BLOCK_COMMENT:
-	'/*' .*? '*/' -> channel(HIDDEN); // Block AKA Multi-line comment.

--- a/Grammar-ANTLR4/YiniLexer.g4
+++ b/Grammar-ANTLR4/YiniLexer.g4
@@ -67,6 +67,8 @@ COMMA: ',';
 COLON: ':';
 OB: '['; // Opening Bracket.
 CB: ']'; // Closing Bracket.
+OC: '{'; // Opening Curly Brace.
+CC: '}'; // Closing Curly Brace.
 PLUS: '+';
 DOLLAR: '$';
 // ASTERIX: '*';
@@ -86,6 +88,7 @@ NULL options {
 	caseInsensitive = true;
 }: 'null';
 
+EMPTY_OBJECT: '{' '}';
 EMPTY_LIST: '[' ']';
 
 SHEBANG: '#!' ~[\n\r\b\f\t]* NL;

--- a/Grammar-ANTLR4/YiniLexer.g4
+++ b/Grammar-ANTLR4/YiniLexer.g4
@@ -170,10 +170,10 @@ SINGLE_OR_DOUBLE:
  *
  * Rather than having the lexer reject on any "illegal" character, lets the
  * parser catch it so you can give a more precise error message. 
-*/
+ *
+ * @note If refactoring rule(s), make sure C-strings can include \' and \" as well.
+ */
 R_AND_C_STRING:
-	// [RrCc]? '\'' ~['\r\n]* '\''
-	// | [RrCc]? '"'	 ~["\r\n]* '"';
 	[RrCc]? '\'' 	('\\\'' | ~['\r\n])* '\''
 	| [RrCc]? '"'	('\\"' | ~["\r\n])* '"';
 

--- a/Grammar-ANTLR4/YiniParser.g4
+++ b/Grammar-ANTLR4/YiniParser.g4
@@ -36,21 +36,40 @@ terminal_line: TERMINAL_TOKEN (NL+ | INLINE_COMMENT? NL*);
 
 section_members: member+;
 
+// -----------------------
+// Key–Value Assignment
+// -----------------------
 member:
 	//| KEY EQ NL+ // Empty value is treated as NULL.
-	KEY EQ value? NL+ // Empty value is treated as NULL.
+	KEY WS? EQ WS? value? NL+ // Empty value is treated as NULL.
 	//| KEY COLON elements? NL+
 	| member_colon_list;
 //| STRING COLON value? NL+; // ???
 
-member_colon_list: KEY COLON elements? NL+;
+member_colon_list: KEY COLON WS? elements? NL+;
 
 value:
-	list_in_brackets
+	null_literal // NOTE: In specs NULL should be case-insensitive.
 	| string_literal
 	| number_literal
 	| boolean_literal
-	| NULL; // NOTE: In specs NULL should be case-insensitive.
+	| list_in_brackets
+	| object_literal;
+
+object_literal
+  : OC NL* objectMemberList NL* CC NL*
+  | EMPTY_OBJECT
+  ;
+
+// A memberList is one or more key=value pairs separated by commas.
+objectMemberList
+    : objectMember ( COMMA NL* objectMember )* ( COMMA )?
+	| EMPTY_OBJECT
+    ;
+    
+objectMember
+    : KEY WS? EQ NL* value
+    ;
 
 list: elements | list_in_brackets;
 
@@ -61,6 +80,7 @@ elements: element COMMA? | element COMMA elements;
 element: NL* value NL* | NL* list_in_brackets NL*;
 
 number_literal: NUMBER;
+null_literal: NULL;
 
 string_literal: STRING string_concat*;
 string_concat: NL* PLUS NL* STRING;

--- a/Grammar-ANTLR4/YiniParser.g4
+++ b/Grammar-ANTLR4/YiniParser.g4
@@ -41,12 +41,12 @@ section_members: member+;
 // -----------------------
 member:
 	//| KEY EQ NL+ // Empty value is treated as NULL.
-	KEY EQ value? NL+ // Empty value is treated as NULL.
+	KEY WS? EQ WS? value? NL+ // Empty value is treated as NULL.
 	//| KEY COLON elements? NL+
 	| member_colon_list;
 //| STRING COLON value? NL+; // ???
 
-member_colon_list: KEY COLON elements? NL+;
+member_colon_list: KEY COLON WS? elements? NL+;
 
 value:
 	null_literal // NOTE: In specs NULL should be case-insensitive.
@@ -68,7 +68,7 @@ objectMemberList
     ;
     
 objectMember
-    : KEY EQ NL* value
+    : KEY WS? EQ NL* value
     ;
 
 list: elements | list_in_brackets;

--- a/Grammar-ANTLR4/YiniParser.g4
+++ b/Grammar-ANTLR4/YiniParser.g4
@@ -36,6 +36,9 @@ terminal_line: TERMINAL_TOKEN (NL+ | INLINE_COMMENT? NL*);
 
 section_members: member+;
 
+// -----------------------
+// Key–Value Assignment
+// -----------------------
 member:
 	//| KEY EQ NL+ // Empty value is treated as NULL.
 	KEY EQ value? NL+ // Empty value is treated as NULL.
@@ -46,11 +49,27 @@ member:
 member_colon_list: KEY COLON elements? NL+;
 
 value:
-	list_in_brackets
+	null_literal // NOTE: In specs NULL should be case-insensitive.
 	| string_literal
 	| number_literal
 	| boolean_literal
-	| NULL; // NOTE: In specs NULL should be case-insensitive.
+	| list_in_brackets
+	| object_literal;
+
+object_literal
+  : OC NL* objectMemberList NL* CC NL*
+  | EMPTY_OBJECT
+  ;
+
+// A memberList is one or more key=value pairs separated by commas.
+objectMemberList
+    : objectMember ( COMMA NL* objectMember )* ( COMMA )?
+	| EMPTY_OBJECT
+    ;
+    
+objectMember
+    : KEY EQ NL* value
+    ;
 
 list: elements | list_in_brackets;
 
@@ -61,6 +80,7 @@ elements: element COMMA? | element COMMA elements;
 element: NL* value NL* | NL* list_in_brackets NL*;
 
 number_literal: NUMBER;
+null_literal: NULL;
 
 string_literal: STRING string_concat*;
 string_concat: NL* PLUS NL* STRING;

--- a/YINI-Specification.md
+++ b/YINI-Specification.md
@@ -600,8 +600,8 @@ To place a section under another (i.e., to nest sections), repeat the section ma
 
 - Section heading markers (`^` or `~`, etc) may only be repeated up to six times — to level 6 (maximum).
 - Beyond level 6, the numeric shorthand section must be used (see section 5.3.1).
-- **Going deeper (increase nesting):** You must increment exactly one level at a time. E.g.: `^^` → `^^^` but not `^^` → `^^^^`.
-- **Going shallower (decrease nesting):** You may drop directly to any previous level. E.g.: `^9` → `^^` or `^9` → `^`.
+- **Going deeper (increase nesting):** Must increment exactly one level at a time. E.g.: `^^` → `^^^` but not `^^` → `^^^^`.
+- **Going shallower (decrease nesting):** May drop directly to any previous level. E.g.: `^9` → `^^` or `^9` → `^`.
 - Optionally the short-hand section notation may be used for level 1 - 6 as well, but it's not preffered (e.g. `^^^` is `^3` interchangeable indeed).
 
 ```yini
@@ -923,12 +923,15 @@ The engine should convert the literal value to the corresponding Boolean value i
 ### 8.2. Null Literal
 Value/literal `NULL` (NON CASE-SENSITIVE). 
 
-- Empty value in section-top-level key-value pair (member), that member is treated as NULL in lenient-mode, error in strict-mode.
-- Inside lists and objects, may contain a trailing comma efter the last value, that comma is ignored. A missing value never produces a null value in list or objects.
+- Empty or missing value in section-top-level key-value pair (member outside any list or object), is treated as NULL in lenient-mode, error in strict-mode.
+  If written `key = `with nothing after `=`, that member’s value is `null` (lenient only; strict mode requires explicitly `key = null`).
+- Note: A missing value never produces a null value inside any list or object.
 
 ## 9. Object Literals
 ### 9.1. Objects (using `{` and `}`)
-YINI supports inline objects as a value type, allowing zero, one or more key–value pairs to be nested inside braces `{` and `}`. An inline object behaves like a map or dictionary: each entry inside `{ ... }` is a standard YINI `key = value` pair, separated by commas. Objects may nest arbitrarily (an object value can itself contain another `{ ... }`).
+YINI supports inline objects as a value type, allowing one or more key–value pairs to be nested inside braces `{` and `}`. An inline object behaves like a map or dictionary: each entry inside `{ ... }` is a standard YINI `key = value` pair, separated by commas. Objects may nest arbitrarily (an object value can itself contain another `{ ... }`).
+
+An empty object `{ }` is only allowed as in lenient-mode.
 
 An object in YINI  have the following form:
 ```txt
@@ -1028,7 +1031,7 @@ list2:  // An empty list.
 **Multi-line List Syntax:**
 Each item in the list may optionally appear on its own line for better readability.
 
-**Commas are required between values**, and a **trailing comma** on the last item is allowed — but ONLY when using colon-based list syntax.
+**Commas are required between values**, and a **trailing comma** on the last item is allowed.
 
 ```yini
 list1:
@@ -1043,7 +1046,7 @@ list2:
 ```
 **Note:** This colon-based list syntax is only valid for lists.
 It must not be used for single values or key-value assignments.
-The trailing comma is ignored in lists ONLY in lenient-mode.
+The trailing comma is ignored in lists (and objects) ONLY in lenient-mode.
 
 ⚠️ **Common Pitfall**
 ```yini
@@ -1185,7 +1188,7 @@ Files **must** be encoded as **UTF-8 without BOM**.
 The document terminator ensures robust parsing boundaries, improves multi-file safety, and aids debugging.
 
 #### 11.2.6. Escaping and String Literals
-- Escape sequences are **ONLY allowed** in Classic strings (quoted with `'` or `"`, **and prefixed** with `C` or `c`).
+- Escape sequences are **ONLY allowed** in in C-Triple-quoted and Classic strings (quoted with `'` or `"`, **and prefixed** with `C` or `c`).
 - Triple-quoted strings must use `"""` for both opening and closing (`'''` is not supported).
 
 #### 11.2.7. Shortest Valid YINI Documents in Strict Mode
@@ -1224,8 +1227,8 @@ Some YINI parsers may support multiple **validation modes**:
   - The document terminator (`/END`) is **optional** in lenient mode and may be omitted entirely.
   - All typing rules still apply — for example, string literals must be quoted: if a value is not quoted, it is not a string — no exceptions.
   - Empty values are allowed ONLY in members in section-top-levels:
-    - Missing value (ONLY outside lists and objects) are treated as `Null`.
-    - Trailing comma (after last value/member) inside lists and object - comma is ignored.
+    - Missing/empty value (ONLY outside lists and objects) are treated as `Null`.
+    - Trailing comma (after last value/member) inside lists and object - comma is ignored - ONLY in lenient-mode.
   - Useful for hand-edited configuration files.
 - **Strict Mode:**
   - Enforces full well-formedness.

--- a/YINI-Specification.md
+++ b/YINI-Specification.md
@@ -107,59 +107,63 @@ For more feedback details, see section D.2, _“Acknowledgments & Special Thanks
 &nbsp;&nbsp;&nbsp;&nbsp;8.1. Booleans  
 &nbsp;&nbsp;&nbsp;&nbsp;8.2. Null Literal
 
-**9. List Literals** ([Link ⇨](./YINI-Specification.md#9-list-literals))  
-&nbsp;&nbsp;&nbsp;&nbsp;9.1. Bracketed Lists (using `=`)  
-&nbsp;&nbsp;&nbsp;&nbsp;9.2. Colon-Based List (using `:`)
+**9. Object Literals** ([Link ⇨](./YINI-Specification.md#9-object-literals))  
+&nbsp;&nbsp;&nbsp;&nbsp;9.1. Objects (using `{` and `}`)  
 
-**10. Advanced Constructs** ([Link ⇨](./YINI-Specification.md#10-advanced-constructs))  
-&nbsp;&nbsp;&nbsp;&nbsp;10.1. Future / Reserved Features _(For Future Use)_  
+**10. List Literals** ([Link ⇨](./YINI-Specification.md#10-list-literals))  
+&nbsp;&nbsp;&nbsp;&nbsp;10.1. Bracketed Lists (using `=`)  
+&nbsp;&nbsp;&nbsp;&nbsp;10.2. Colon-Based List (using `:`)
+
+**11. Advanced Constructs** ([Link ⇨](./YINI-Specification.md#11-advanced-constructs))  
+&nbsp;&nbsp;&nbsp;&nbsp;11.1. Future / Reserved Features _(For Future Use)_  
 
 ---
 
 ### **Part III – Validation, Implementation & Compatibility**
 
-**11. Validation Rules** ([Link ⇨](./YINI-Specification.md#11-validation-rules))  
-&nbsp;&nbsp;&nbsp;&nbsp;11.1. Reserved Syntax  
-&nbsp;&nbsp;&nbsp;&nbsp;11.2. Well-Formedness Requirements  
-&nbsp;&nbsp;&nbsp;&nbsp;11.3. Lenient vs. Strict Modes _(Optional Feature)_  
+**12. Validation Rules** ([Link ⇨](./YINI-Specification.md#12-validation-rules))  
+&nbsp;&nbsp;&nbsp;&nbsp;12.1. Reserved Syntax  
+&nbsp;&nbsp;&nbsp;&nbsp;12.2. Well-Formedness Requirements  
+&nbsp;&nbsp;&nbsp;&nbsp;12.3. Lenient vs. Strict Modes _(Optional Feature)_  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;11.3.1. Table: Lenient vs. Strict Mode
 
-**12. Implementation Notes** ([Link ⇨](./YINI-Specification.md#12-implementation-notes))  
-&nbsp;&nbsp;&nbsp;&nbsp;12.1. Top-Level Sections and Implicit Root  
-&nbsp;&nbsp;&nbsp;&nbsp;12.2. Line Handling and Whitespace  
-&nbsp;&nbsp;&nbsp;&nbsp;12.3. Value and NULL Handling  
-&nbsp;&nbsp;&nbsp;&nbsp;12.4. Boolean Canonicalization  
-&nbsp;&nbsp;&nbsp;&nbsp;12.5. Lists  
-&nbsp;&nbsp;&nbsp;&nbsp;12.6. Strings Concatenation  
-&nbsp;&nbsp;&nbsp;&nbsp;12.7. String Literal Types  
-&nbsp;&nbsp;&nbsp;&nbsp;12.8. Comments  
-&nbsp;&nbsp;&nbsp;&nbsp;12.9. Error Handling Recommendations  
-&nbsp;&nbsp;&nbsp;&nbsp;12.10. Bonus Tips for Implementation
+**13. Implementation Notes** ([Link ⇨](./YINI-Specification.md#13-implementation-notes))  
+&nbsp;&nbsp;&nbsp;&nbsp;13.1. Top-Level Sections and Implicit Root  
+&nbsp;&nbsp;&nbsp;&nbsp;13.2. Line Handling and Whitespace  
+&nbsp;&nbsp;&nbsp;&nbsp;13.3. Value and NULL Handling  
+&nbsp;&nbsp;&nbsp;&nbsp;13.4. Boolean Canonicalization  
+&nbsp;&nbsp;&nbsp;&nbsp;13.5. Objects  
+&nbsp;&nbsp;&nbsp;&nbsp;13.6. Lists  
+&nbsp;&nbsp;&nbsp;&nbsp;13.7. Strings Concatenation  
+&nbsp;&nbsp;&nbsp;&nbsp;13.8. String Literal Types  
+&nbsp;&nbsp;&nbsp;&nbsp;13.9. Comments  
+&nbsp;&nbsp;&nbsp;&nbsp;13.10. Error Handling Recommendations  
+&nbsp;&nbsp;&nbsp;&nbsp;13.11. Bonus Tips for Implementation
 
-**13. Compatibility and Versioning** ([Link ⇨](./YINI-Specification.md#13-compatibility-and-versioning))  
-&nbsp;&nbsp;&nbsp;&nbsp;13.1. Fallback Rules  
-&nbsp;&nbsp;&nbsp;&nbsp;13.2. Versioning Strategy  
-&nbsp;&nbsp;&nbsp;&nbsp;13.3. Encoding Notes  
-&nbsp;&nbsp;&nbsp;&nbsp;13.4. JSON Compatibility
+**14. Compatibility and Versioning** ([Link ⇨](./YINI-Specification.md#14-compatibility-and-versioning))  
+&nbsp;&nbsp;&nbsp;&nbsp;14.1. Fallback Rules  
+&nbsp;&nbsp;&nbsp;&nbsp;14.2. Versioning Strategy  
+&nbsp;&nbsp;&nbsp;&nbsp;14.3. Encoding Notes  
+&nbsp;&nbsp;&nbsp;&nbsp;14.4. JSON Compatibility
 
 ---
 
 ### **Part IV – Examples and Appendices**
 
-**14. Examples** ([Link ⇨](./YINI-Specification.md#14-examples))  
-&nbsp;&nbsp;&nbsp;&nbsp;14.1. Minimal Example  
-&nbsp;&nbsp;&nbsp;&nbsp;14.2. Realistic Config Use Cases  
-&nbsp;&nbsp;&nbsp;&nbsp;14.3. Examples of YINI → JSON Mapping  
-&nbsp;&nbsp;&nbsp;&nbsp;14.4. Examples of JSON → YINI Mapping  
+**15. Examples** ([Link ⇨](./YINI-Specification.md#15-examples))  
+&nbsp;&nbsp;&nbsp;&nbsp;15.1. Minimal Example  
+&nbsp;&nbsp;&nbsp;&nbsp;15.2. Realistic Config Use Cases  
+&nbsp;&nbsp;&nbsp;&nbsp;15.3. Examples of YINI → JSON Mapping  
+&nbsp;&nbsp;&nbsp;&nbsp;15.4. Examples of JSON → YINI Mapping  
 
-**15. Appendices and Reserved Areas** ([Link ⇨](./YINI-Specification.md#15-appendices-and-reserved-areas))  
-&nbsp;&nbsp;&nbsp;&nbsp;15.1. License  
-&nbsp;&nbsp;&nbsp;&nbsp;15.2. Acknowledgments  
-&nbsp;&nbsp;&nbsp;&nbsp;15.3. Author(s)  
-&nbsp;&nbsp;&nbsp;&nbsp;15.4. Spec Changes  
-&nbsp;&nbsp;&nbsp;&nbsp;15.5. Reserved: Grammar (Formal)  
-&nbsp;&nbsp;&nbsp;&nbsp;15.6. Appendix C – Common Mistakes and Pitfalls  
-&nbsp;&nbsp;&nbsp;&nbsp;15.7. 🧾 Unicode Whitespace Characters  
+**16. Appendices and Reserved Areas** ([Link ⇨](./YINI-Specification.md#16-appendices-and-reserved-areas))  
+&nbsp;&nbsp;&nbsp;&nbsp;16.1. License  
+&nbsp;&nbsp;&nbsp;&nbsp;16.2. Acknowledgments  
+&nbsp;&nbsp;&nbsp;&nbsp;16.3. Author(s)  
+&nbsp;&nbsp;&nbsp;&nbsp;16.4. Spec Changes  
+&nbsp;&nbsp;&nbsp;&nbsp;16.5. Reserved: Grammar (Formal)  
+&nbsp;&nbsp;&nbsp;&nbsp;16.6. Appendix C – Common Mistakes and Pitfalls  
+&nbsp;&nbsp;&nbsp;&nbsp;16.7. 🧾 Unicode Whitespace Characters  
 
 ---
 
@@ -315,7 +319,7 @@ While YINI is not indentation-sensitive, the following whitespace `<WS>` behavio
 - Newlines (`<NL>`) may be either Unix/Linux-style (`LF`, U+000A), Windows-style (`CRLF`, U+000D U+000A), or (`CR`, U+000D).
 - Tabs (`<TAB>`, U+0009) and spaces (`<SPACE>`, U+0020) are ignored outside of strings and section headers.
 - Indentation using whitespace is allowed purely for visual clarity — it has no effect on parsing or structure.
-- Note: In the context of strings, the term `<Unicode-WS>` is used to refer to a broader range of Unicode whitespace characters, beyond just tab and space. For a complete table, see more in section 15.7, "🧾 Unicode Whitespace Characters".
+- Note: In the context of strings, the term `<Unicode-WS>` is used to refer to a broader range of Unicode whitespace characters, beyond just tab and space. For a complete table, see more in section 16.7, "🧾 Unicode Whitespace Characters".
 
 ### 3.3. Comments
 YINI supports **three types of comments**:
@@ -483,6 +487,7 @@ A YINI _**value**_ can be of one of the following three groups of native/built-i
   - Boolean
 
 - **Compound types:**
+  - Object (similar to a map) — a sequence of key-value pairs (members), separated by commas
   - List (also known as Arrays) — a sequence of values, separated by commas
 
 - **Special type:**
@@ -591,10 +596,13 @@ That is, the following denote nesting levels 1–6:
 To represent nesting deeper than level 6, switch to the **numeric shorthand section header** syntax (see Section 5.3.1).
 
 ### 5.3. Nested Sections
-To place a section under another (i.e., to nest sections), repeat the section marker character (this technique with repeating characters is inspired by Markdown) without skipping any intermediate levels. Each additional repetition indicates one more nesting level. However, when moving to a less‐nested (shallower) level, you may drop directly to any smaller level.
+To place a section under another (i.e., to nest sections), repeat the section marker character (this technique with repeating characters is inspired by Markdown) without skipping any intermediate levels. Each additional repetition indicates one more nesting level. However, when moving to a less‐nested (closer to section header) level, you may drop directly to any smaller level.
 
-- Section heading markers (`^` or `~`, etc) may only be repeated up to six times — to level 6.
+- Section heading markers (`^` or `~`, etc) may only be repeated up to six times — to level 6 (maximum).
 - Beyond level 6, the numeric shorthand section must be used (see section 5.3.1).
+- **Going deeper (increase nesting):** Must increment exactly one level at a time. E.g.: `^^` → `^^^` but not `^^` → `^^^^`.
+- **Going shallower (decrease nesting):** May drop directly to any previous level. E.g.: `^9` → `^^` or `^9` → `^`.
+- Optionally the short-hand section notation may be used for level 1 - 6 as well, but it's not preffered (e.g. `^^^` is `^3` interchangeable indeed).
 
 ```yini
 ^ Prefs
@@ -634,7 +642,7 @@ Optionally, indentation may be omitted:
 #### 5.3.1. Short-hand Section Heading
 
 **Short-hand Section Headings:**
-Numeric shorthand is required when nesting beyond six levels with the same marker (e.g., `^`). The syntax is `<marker><n>`, where `<marker>` is one of the allowed section marker characters (`^`, `~`, etc.) and `<n>` is an integer ≥ 1 indicating the nesting level. For example:
+Numeric shorthand is required when nesting beyond six levels with the same marker (e.g., `^`). The syntax is `<marker><n>`, where `<marker>` is one of the allowed section marker characters (`^`, `~`, etc.) and `<n>` is an integer ≥ 6 indicating the nesting level (alternativily, integer ≥ 1 is allowed, but not recommended). For example:
 
 - To go from depth 6 to depth 7: write `^7`.  
 - To go from depth 7 to depth 8: write `^8`.  
@@ -765,11 +773,11 @@ Like raw strings, Hyper Strings treat backslashes as literal characters — esca
 Hyper Strings are designed to be **multi-line friendly** and **visually readable**, especially for long text blocks:
 
 - `<NL>` refers to newline/linebreak of in combination of `CR`, `LF`, or `CRLF`.
-`<Unicode-WS>` includes all relevant Unicode whitespace characters: the categories `Zs` (space separators), `Zl` (line separators), `Zp` (paragraph separators), and selected `Cc` (control characters), primarily from the C0 range (`U+0000–U+001F`). For a complete table, see more in section 15.7, "🧾 Unicode Whitespace Characters".
+`<Unicode-WS>` includes all relevant Unicode whitespace characters: the categories `Zs` (space separators), `Zl` (line separators), `Zp` (paragraph separators), and selected `Cc` (control characters), primarily from the C0 range (`U+0000–U+001F`). For a complete table, see more in section 16.7, "🧾 Unicode Whitespace Characters".
 - Hyper Strings **can span multiple lines**, and indentation using `<Unicode-WS>` is allowed to improve human readability.
 - Multiple consecutive newlines (`<NL>`) and/or whitespace (`<Unicode-WS>`) are normalized into a **single space** (`U+0020`).
 - Leading and trailing `<NL>` and/or `<Unicode-WS>` are trimmed.
-- For the complete set of characters in <Unicode-WS>, refer to section 15.7 — [Unicode Whitespace Characters.](./YINI-Specification.md#157--unicode-whitespace-characters)
+- For the complete set of characters in <Unicode-WS>, refer to section 16.7 — [Unicode Whitespace Characters.](./YINI-Specification.md#157--unicode-whitespace-characters)
 
 Hyper Strings behave similarly to how text is rendered in HTML: extra spacing and line breaks are reduced to clean, flowing text.
 
@@ -915,9 +923,44 @@ The engine should convert the literal value to the corresponding Boolean value i
 ### 8.2. Null Literal
 Value/literal `NULL` (NON CASE-SENSITIVE). 
 
-Also if value is missing in member, then that member is treated as NULL.
+- Empty or missing value in section-top-level key-value pair (member outside any list or object), is treated as NULL in lenient-mode, error in strict-mode.
+  If written `key = `with nothing after `=`, that member’s value is `null` (lenient only; strict mode requires explicitly `key = null`).
+- Note: A missing value never produces a null value inside any list or object.
 
-## 9. List Literals
+## 9. Object Literals
+### 9.1. Objects (using `{` and `}`)
+YINI supports inline objects as a value type, allowing one or more key–value pairs to be nested inside braces `{` and `}`. An inline object behaves like a map or dictionary: each entry inside `{ ... }` is a standard YINI `key = value` pair, separated by commas. Objects may nest arbitrarily (an object value can itself contain another `{ ... }`).
+
+An empty object `{ }` is only allowed as in lenient-mode.
+
+An object in YINI  have the following form:
+```txt
+<identifier> = { <key1> = <value1>, <key2> = <value2>, ... }
+```
+
+- The **key** in each member follows the same rules as any YINI identifier.
+The **value** in each member may be:
+  * A string (quoted with `'...'`).
+  * A number (integer or float).
+  * A boolean (true/false/on/off).
+  * A list (`[ ... ]`).
+  * Another inline object (`{ ... }`).
+  * An empty object `{ }` is allowed as well only in lenient-mode.
+
+The following rules apply to objects in YINI:
+- Begins with `{` and ends with `}`.
+- Between `{` and `}`, write one or more members (also zero members is allowed in lenient-mode, while in strict-mode it must include at least one member) of the form `key = value` (a member), separated by commas.
+- Optionally and only in lenient-mode, after a value allow a trailing comma before the closing `}`
+- Whitespace (spaces, tabs, newlines) is ignored except inside quoted strings.
+- Comments (e.g. `// ...` or `# ...`) may appear anywhere whitespace is allowed.
+
+**Example:**
+```yini
+^ section
+object = { member1 = "value1", member2 = "value2" }
+```
+
+## 10. List Literals
 Lists in YINI correspond to what are called _Arrays_ in JSON and serve the same purpose as arrays in many programming languages (e.g., in JavaScript).
 
 YINI supports two ways to define lists:
@@ -926,7 +969,7 @@ YINI supports two ways to define lists:
 
 Note: Only lists can use the alternative notation using `:`.
 
-### 9.1. Bracketed Lists (using `=`)
+### 10.1. Bracketed Lists (using `=`)
 A list can be assigned to a key using the equals sign `=`, followed by square brackets `[ ]` containing zero or more comma-separated values.
 
 Whitespace (spaces, tabs, and newlines) is allowed within the brackets.
@@ -937,7 +980,7 @@ list2 = [100, 200, 300]
 list3 = []  // An empty list.
 ```
 
-For convenience, a trailing comma (`,`) may be optionally be included.
+For convenience, a trailing comma (`,`) may be optionally be included (only in lenient-mode).
 
 ```yini
 // A list with THREE items.
@@ -974,7 +1017,7 @@ linkItems = [
 ]
 ```
 
-### 9.2. Colon-Based List (using `:`)
+### 10.2. Colon-Based List (using `:`)
 Exclusively for lists, YINI allows an alternative syntax using a colon (`:`) instead of `=`. This style omits square brackets and is intended to improve readability in configurations with list-like values.
 
 Note: Commas are mandatory after items (except after the last item), even in multi-line forms in this notation.
@@ -988,7 +1031,7 @@ list2:  // An empty list.
 **Multi-line List Syntax:**
 Each item in the list may optionally appear on its own line for better readability.
 
-**Commas are required between values**, and a **trailing comma** on the last item is allowed — but ONLY when using colon-based list syntax.
+**Commas are required between values**, and a **trailing comma** on the last item is allowed.
 
 ```yini
 list1:
@@ -999,11 +1042,11 @@ list1:
 list2:
   "oranges",
   "bananas",
-  "peaches",  // Trailing comma is valid here, and is ignored.
+  "peaches",  // Trailing comma is valid here, and is ignored. (Only in lenient-mode.)
 ```
 **Note:** This colon-based list syntax is only valid for lists.
 It must not be used for single values or key-value assignments.
-The trailing comma is ignored ONLY in `:` based lists.
+The trailing comma is ignored in lists (and objects) ONLY in lenient-mode.
 
 ⚠️ **Common Pitfall**
 ```yini
@@ -1017,8 +1060,11 @@ name = "John"  // ✅ A single string value.
 **Colon (`:`) is not a substitute for `=`** and must not be used for regular member (non list) assignments.
 
 **Trailing Comma Behavior**
-- In colon-based lists, a **trailing comma is ignored** (legal, optional).
-- In bracketed lists (`[ ... ]`), a **trailing comma results in an implicit** `null` as the last item.
+- In objects, a **trailing comma is ignored** (legal in lenient-mode, optional).
+- In colon-based lists, a **trailing comma is ignored** (legal in lenient-mode, optional).
+- In bracketed lists (`[ ... ]`), a **trailing comma is ignored** (legal in 
+lenient-mode, optional).
+  
 
 **Termination Rule**
 
@@ -1036,23 +1082,17 @@ linkItems:
 	["stylesheet", "css/themes.css"]
 ```
 
-## 10. Advanced Constructs
-### 10.1. Future / Reserved Features _(For Future Use)_
+## 11. Advanced Constructs
+### 11.1. Future / Reserved Features _(For Future Use)_
 The following features are reserved for potential support in future versions of the YINI specification. They are **not currently active** in this version, but their syntax and keywords **are reserved**.
 
-#### 10.1.1. Short-hand Section Marker
-Support for an alternative, shorter version of the section marker is planned to be added in the near future. 
-
-#### 10.1.2. Inline Objects
-Support for inline objects (e.g., within lists) is planned in the near future. 
-
-#### 10.1.3. Anchors and Aliases
+#### 11.1.1. Anchors and Aliases
 YINI may introduce a mechanism similar to YAML’s anchors and aliases. These constructs would allow users to define reusable fragments within a configuration.
 
   - **Anchors (`@`):** Or some other token, to assign a name to a key, section, or structure.
   - **Aliases (`use`):** Reference a previously defined anchor using the use keyword.
 
-#### 10.1.4. Includes
+#### 11.1.2. Includes
 YINI may support modular configuration files via external file inclusion.
   - **Directive:** `@include "<path/to/file>"`
   - **Description:** Imports the contents of another YINI file into the current one.
@@ -1060,19 +1100,19 @@ YINI may support modular configuration files via external file inclusion.
 
 These features, while not implemented in this version, are reserved and must not be repurposed by user-defined syntax.
 
-#### 10.1.5. Date-time Type
+#### 11.1.3. Date-time Type
 
 Currently, the YINI types in the specification map 1-to-1 to native JSON types. With that said YINI does not currently support native date, time, or date-time types. All date and time values **must currently** be represented as strings.
 
 Support for standardized date-time literals may be considered in a future version, once the core specification is stable.
 
-## 11. Validation Rules
+## 12. Validation Rules
 YINI enforces a set of validation rules to ensure the structure and content of files are consistent, unambiguous, and semantically correct. These rules fall into two main categories: **reserved syntax protections** and **well-formedness**. Validation ensures compatibility across implementations and minimizes user errors.
 
-### 11.1. Reserved Syntax
+### 12.1. Reserved Syntax
 Certain characters and keywords are **reserved** by the YINI specification for internal syntax or future use. Using them incorrectly may lead to a parse error or undefined behavior.
 
-#### 11.1.1. Reserved Characters
+#### 12.1.1. Reserved Characters
 The following characters are reserved by the YINI syntax and must not be used improperly outside of their defined contexts. They may appear inside quoted strings or phrase identifiers but are otherwise restricted:
 
 | Character	| Usage Context	| Description |
@@ -1092,7 +1132,7 @@ The following characters are reserved by the YINI syntax and must not be used im
 | `{ }` |  | Reserved for future syntax |
 | `--` | Line disabling | Experimental use (see Section 3.6) |
 
-#### 11.1.2. Reserved Keywords
+#### 12.1.2. Reserved Keywords
 The following keywords are restricted and must not be used as bare identifiers (e.g., for keys, values, or section names) unless enclosed in quotes or backticks:
 - `/END` _(case-insensitive)_
 - `@yini`
@@ -1101,7 +1141,7 @@ The following keywords are restricted and must not be used as bare identifiers (
 
 Use of these keywords outside their defined roles may result in a parse error.
 
-### 11.2. Well-Formedness Requirements
+### 12.2. Well-Formedness Requirements
 A YINI file is considered **well-formed** if it adheres to the core syntactic and structural rules defined in this specification.
 
 #### 11.2.1. Structural Requirements
@@ -1148,7 +1188,7 @@ Files **must** be encoded as **UTF-8 without BOM**.
 The document terminator ensures robust parsing boundaries, improves multi-file safety, and aids debugging.
 
 #### 11.2.6. Escaping and String Literals
-- Escape sequences are **ONLY allowed** in Classic strings (quoted with `'` or `"`, **and prefixed** with `C` or `c`).
+- Escape sequences are **ONLY allowed** in in C-Triple-quoted and Classic strings (quoted with `'` or `"`, **and prefixed** with `C` or `c`).
 - Triple-quoted strings must use `"""` for both opening and closing (`'''` is not supported).
 
 #### 11.2.7. Shortest Valid YINI Documents in Strict Mode
@@ -1177,15 +1217,18 @@ The document terminator ensures robust parsing boundaries, improves multi-file s
     ```
     **Note:** Invalid: file contains only a comment and lacks both `/END` and title section.
 
-### 11.3. Lenient vs. Strict Modes _(Optional Feature)_
+### 12.3. Lenient vs. Strict Modes _(Optional Feature)_
 Non-strict mode (lenient mode) is the default and recommended mode of operation. Parsers should operate in this mode by default unless explicitly configured otherwise to operate in fully strict mode.
 
 Some YINI parsers may support multiple **validation modes**:
 
 - **Lenient Mode:** 
-  - Permissive with minor errors (e.g., trailing commas, mixed line endings).
+  - Permissive with minor errors (e.g., trailing commas after last value/member (are ignored), mixed line endings).
   - The document terminator (`/END`) is **optional** in lenient mode and may be omitted entirely.
   - All typing rules still apply — for example, string literals must be quoted: if a value is not quoted, it is not a string — no exceptions.
+  - Empty values are allowed ONLY in members in section-top-levels:
+    - Missing/empty value (ONLY outside lists and objects) are treated as `Null`.
+    - Trailing comma (after last value/member) inside lists and object - comma is ignored - ONLY in lenient-mode.
   - Useful for hand-edited configuration files.
 - **Strict Mode:**
   - Enforces full well-formedness.
@@ -1200,26 +1243,28 @@ Some YINI parsers may support multiple **validation modes**:
 
 **Note:** Implementations must clearly document the validation mode in use and detail which rules are fully enforced under strict parsing.
 
-### 11.3.1. Table: Lenient vs. Strict Mode
+### 12.3.1. Table: Lenient vs. Strict Mode
 | Feature                 | Lenient Mode (Default) | Strict Mode | Notes |
 |-------------------------|:----------------------:|:-----------:|-------|
-| Explicit string quoting     | ✅ | ✅ | All strings must be enclosed with `"` or `'` — no ambiguity over strings.|
-| Empty sections allowed | ✅ | ✅ | Sections may contain no members (e.g., `^ Config`). |
-| Duplicate keys          | ❌ | ❌ |   |
-| One level 1 section header | ❌ | ✅ |   |
-| `/END` required         | ❌ | ✅ |   |
-| Trailing commas         | ✅ | ❌ |   |
-| Invalid escape sequences| ✅ (may warn) | ❌ (error) |   |
+| Explicit string quoting               | ✅ | ✅ | All strings must be enclosed with `"` or `'` — no ambiguity over strings.|
+| Empty sections allowed                | ✅ | ✅ | Sections may contain no members (e.g., `^ Config`). |
+| Duplicate keys                        | ❌ | ❌ |   |
+| One level 1 section header            | ❌ | ✅ |   |
+| `/END` required                       | ❌ | ✅ |   |
+| Trailing commas after value (inside lists/objects)| ✅ | ❌ | In lenient-mode the comma is ignored, error in strict-mode  |
+| Missing (empty) value (only in section-top-level)| ✅ | ❌ | Will result in a `Null` value in lenient-mode  |
+| Missing (empty) value before comma | - | ❌ | In lenient-mode must warn or make error  |
+| Invalid escape sequences              | ✅ (may warn) | ❌ (error) |   |
 
 ⚠️ Strict mode enforces a stricter contract suitable for automated validation and reproducible builds. Lenient mode favors user-friendliness and flexibility for human editing.
 
-## 12. Implementation Notes
+## 13. Implementation Notes
 
 The following guidance is intended to assist developers implementing YINI parsers, engines, or tools. These notes aim to promote consistent interpretation of YINI syntax across different platforms and environments.
 
 See also [Section 11.2: Well-Formedness Requirements] for formal validation criteria.
 
-### 12.1. Top-Level Sections and Implicit Root
+### 13.1. Top-Level Sections and Implicit Root
 
 * If a document contains **multiple top-level sections** (i.e., multiple level-1 sections), they must be considered **children of an implicit root**.
 * The implicit root section:
@@ -1228,7 +1273,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   - A level-3 section **must follow** a level-2 section.
   - Skipping levels (e.g., directly from level-1 to level-3) is invalid.
 
-### 12.2. Line Handling and Whitespace
+### 13.2. Line Handling and Whitespace
 
 * Newline normalization is required:
   * Support all three forms: LF (`0x0A`), CRLF (`0x0D 0x0A`), and CR (`0x0D`.
@@ -1240,7 +1285,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
 * Full-line and inline comments may follow key-value members or appear on separate lines.
 * Whitespace is permitted within lists, including across lines.
 
-### 12.3. Value and NULL Handling
+### 13.3. Value and NULL Handling
 
 * If a key is assigned without a value::
   ```yini
@@ -1252,7 +1297,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   - Keys must be **unique within the same section and section level**.
   - Duplicates in the same section are a **parse error**.
 
-### 12.4. Boolean Canonicalization
+### 13.4. Boolean Canonicalization
 
 * Boolean literals are **case-insensitive**.
 * The following values must be interpreted as Booleans:
@@ -1260,15 +1305,22 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   * `false`, `no`, `off` → `false`
 * Do not allow Boolean values like `1` or `0` unless explicitly cast by the host software.
 
-### 12.5 Lists
+### 13.5. Objects
+Any empty slot inside `{ ... }` e.g.:
+```
+object = { a = 1, , b = 2 }
+```
 
+is error in strict-mode or at least a warning (in lenient-mode).
+
+### 13.6. Lists
 * Two syntaxes are valid for lists:
   - **(a) Bracketed form (preferred):**
     ```yini
     items = ["a", "b", "c"]
     ```
       * A bracketed list line must not begin with a comma.
-      * A trailing comma in `[ ]` is treated as a `null` value.
+      * A trailing comma in `[ ]` is ignored.
   - **(b) Unbracketed multiline:**
     ```yini
     items1: "a", "b", "c"
@@ -1286,7 +1338,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   [1, 2, 3]     // Not parsed as a list!
   ```
 
-### 12.6 Strings Concatenation
+### 13.7. Strings Concatenation
 
 * Strings can be concatenated using the `+` operator:
     ```yini
@@ -1296,7 +1348,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
 * Concatenating different types of strings (e.g., r"..." + c'...') is **permitted** (for use in some special or advanced cases), but generally **discouraged**.
 * Only Classic strings (C-Strings) interpret escape sequences (`\n`, `\t`, etc).
 
-### 12.7 String Literal Types
+### 13.8. String Literal Types
 **Note:** If a string is not quoted, it's not a string — period.
 
 | Type                   | Prefix           | Example    | Behavior |
@@ -1312,7 +1364,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   * Collapse sequences of whitespace and newlines into a single space.
   * Trim leading/trailing whitespace.
 
-### 12.8 Comments
+### 13.9. Comments
 
 * YINI supports:
   - `//` for inline comments (rest of the line is ignored).
@@ -1321,7 +1373,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   - `;`at start of line is treated as full-line comments (there may appear only spaces or tabs before `;`).
   - **Nested block comments are not supported.**
 
-### 12.9 Error Handling Recommendations
+### 13.10. Error Handling Recommendations
 
 If the parser encounters:
   * A **missing intermediate section level** (e.g., level 3 without level 2),
@@ -1332,7 +1384,7 @@ It should:
 * **Fail gracefully** and report an error, OR
 * **Use host-defined fallback logic**, if robustness is preferred.
 
-### 12.10 Bonus Tips for Implementation
+### 13.11 Bonus Tips for Implementation
 Developers are encouraged to implement the following features to improve parser robustness and developer experience:
 
 - Attach **position metadata** (line/column) to tokens for better diagnostics.
@@ -1347,18 +1399,18 @@ Developers are encouraged to implement the following features to improve parser 
   - Level 2 = abort even on warnings
 - **Extra Bonus:** In strings, if C/C++-style octal escape codes like `\1` to `\377` are used (which are not valid in YINI), parsers should treat this as an error in strict mode (and suggest the correct YINI syntax). In lenient mode, parsers may optionally emit a warning and suggest the correct YINI syntax: `\o1` to `\o377`, and interpret the octal code as intended.
 
-## 13. Compatibility and Versioning
+## 14. Compatibility and Versioning
 This section covers YINI's compatibility and interoperability principles.
 
-### 13.1. Fallback Rules
-#### 13.1.1. Invalid Sections or Keys
+### 14.1. Fallback Rules
+#### 14.1.1. Invalid Sections or Keys
 - Invalid key names or section headers **should be retained as-is** if possible and/or illegal characters remapped (both in lenient and strict mode, and optionally also support "Abort Sensitivity Levels"), though at least a warning should be issued depending on it's severity.
   
-#### 13.1.2. Graceful Degradation
+#### 14.1.2. Graceful Degradation
 - Parsers should issue warnings instead of errors when encountering unrecognized features (e.g., unknown directives, anchors, or section markers).
 - Implementations should strive to process known-valid content even if advanced features are not supported.
 
-### 13.2. Versioning Strategy
+### 14.2. Versioning Strategy
 **Version Format**
 
 - In the future, the YINI Specification will adopt _Semantic Versioning_ (`MAJOR.MINOR.PATCH STAGE`) to signal format evolution.
@@ -1369,24 +1421,24 @@ Semantic Versioning:
 - **MINOR:** Backward-compatible additions.
 - **PATCH:** Backward-compatible fixes.
 
-### 13.3. Encoding Notes
-#### 13.3.1 Required Encoding
+### 14.3. Encoding Notes
+#### 14.3.1 Required Encoding
 - **UTF-8 without BOM** is the required and default encoding for YINI files.
 - Parsers must support UTF-8 fully.
 - Use of other encodings (e.g., UTF-16, Latin-1) is discouraged and not guaranteed to be portable.
 
-#### 13.3.2 Byte Order Mark (BOM)
+#### 14.3.2 Byte Order Mark (BOM)
 - A UTF-8 BOM (`0xEF 0xBB 0xBF`) is **not required** and **should be avoided**.
 - If present, parsers must detect and ignore the BOM without failing.
 
-#### 13.3.3 Shebang Line (Optional)
+#### 14.3.3 Shebang Line (Optional)
 A shebang line may be used at the very top of the file:
 ```
 #!/usr/bin/env yini
 ```
 This line is ignored by YINI parsers but may affect script execution in Unix environments. It must be ignored by the YINI parser as a comment or metadata line.
 
-### 13.4. JSON Compatibility
+### 14.4. JSON Compatibility
 
 A valid YINI file can be converted into a valid JSON file (and vice versa) while preserving **data structure, types, and identifier names exactly**.
 
@@ -1423,9 +1475,9 @@ Conversely, a valid JSON object can be mapped into a YINI document, provided tha
 ### See also:
 See Sections 14.3 and 14.4 for examples of YINI ⇆ JSON mappings.
 
-## 14. Examples
+## 15. Examples
 
-### 14.1. Minimal Example
+### 15.1. Minimal Example
 ```yini
 ^ Prefs
 
@@ -1438,8 +1490,8 @@ enabled = true
   - Begins with a single section `# Prefs`.
   - Contains three keys (`name`, `entries`, `enabled`) with string, number, and boolean values, respectively.
 
-### 14.2. Realistic Config Use Cases
-#### 14.2.1. User Preferences Configuration
+### 15.2. Realistic Config Use Cases
+#### 15.2.1. User Preferences Configuration
 ```yini
 ^ Preferences
 
@@ -1454,7 +1506,7 @@ recent_files = [
 ]
 ```
 
-#### 14.2.2. Application Settings with Sections
+#### 15.2.2. Application Settings with Sections
 ```yini
 ^ Database
 host = "localhost"
@@ -1476,7 +1528,7 @@ api_version = "v2.1"
 **Notes:**
 - The `^` marker cleanly divides logical domains into sections.
 
-#### 14.2.3. Script Metadata
+#### 15.2.3. Script Metadata
 ```yini
 ^ Metadata
 name = "Data Fetch Script"
@@ -1486,7 +1538,7 @@ schedule = "daily"
 active = true
 ```
 
-#### 14.2.4. Feature Flags
+#### 15.2.4. Feature Flags
 ```yini
 ^ FeatureFlags
 debug = true
@@ -1496,7 +1548,7 @@ cache_expiry = 86400  		// In seconds
 last_purge_date = "2025-05-25"	// YYYY-MM-DD
 ```
 
-#### 14.2.5. Feature Toggles with Alternative Syntax
+#### 15.2.5. Feature Toggles with Alternative Syntax
 ```yini
 /*
   Feature Toggles with Alternative Syntax
@@ -1519,9 +1571,9 @@ last_purge_date = "2025-05-25"	// YYYY-MM-DD
 - \`Cache Config\` is a nested subsection of \`Feature Toggles\`.
 - All keys and section header identifiers are enclosed in backticks, allowing the use of spaces and special characters.
 
-### 14.3. Examples of YINI → JSON Mapping
+### 15.3. Examples of YINI → JSON Mapping
 
-#### 14.3.1. Simple Flat Structure to JSON
+#### 15.3.1. Simple Flat Structure to JSON
 **YINI:**
 ```yini
 ^ User
@@ -1541,7 +1593,7 @@ active = true
 }
 ```
 
-#### 14.3.2. Nested Sections (multiple levels) to JSON
+#### 15.3.2. Nested Sections (multiple levels) to JSON
 **YINI:**
 ```yini
 ^ Settings
@@ -1567,7 +1619,7 @@ language = "en"
 }
 ```
 
-#### 14.3.3. Lists (Arrays) to JSON
+#### 15.3.3. Lists (Arrays) to JSON
 **YINI:**
 ```yini
 ^ Server
@@ -1586,7 +1638,7 @@ hosts = ['server1.example.com', 'server2.example.com']
 }
 ```
 
-#### 14.3.4. Nulls and Booleans to JSON
+#### 15.3.4. Nulls and Booleans to JSON
 
 **Note:** Null and boolean literals (e.g., `Null`, `True`, `On`, `Yes`) in YINI are **case-insensitive**, while keys are **case-sensitive**.
 
@@ -1609,9 +1661,9 @@ description = Null
 }
 ```
 
-### 14.4. Examples of JSON → YINI Mapping
+### 15.4. Examples of JSON → YINI Mapping
 
-#### 14.4.1. Simple JSON Object to YINI
+#### 15.4.1. Simple JSON Object to YINI
 **JSON:**
 ```json
 {
@@ -1631,7 +1683,7 @@ age = 35
 verified = true
 ```
 
-#### 14.4.2. Nested JSON Objects to YINI
+#### 15.4.2. Nested JSON Objects to YINI
 **JSON:**
 ```json
 {
@@ -1655,7 +1707,7 @@ version = "2.5"
     notifications = true
 ```
 
-#### 14.4.3. JSON Array to YINI
+#### 15.4.3. JSON Array to YINI
 **JSON:**
 ```json
 {
@@ -1671,19 +1723,19 @@ version = "2.5"
 hosts = ["alpha.local", "beta.local", "gamma.local"]
 ```
 
-## 15. Appendices and Reserved Areas
-### 15.1. License
+## 16. Appendices and Reserved Areas
+### 16.1. License
 Apache License, Version 2.0, January 2004,
 http://www.apache.org/licenses/
 Copyright 2024-2025 Gothenburg, Marko K. Seppänen. (Sweden via
 Finland).
 
-### 15.2. Acknowledgments
+### 16.2. Acknowledgments
 _YINI would not exist in this form and shape what it is today, without the many insights, challenges, and thoughtful, constructive feedback from the community.
 
 For more details, see section D.2, _“Acknowledgments & Special Thanks”_, in the [Rationale](./RATIONALE.md) document.
 
-### 15.3. Author(s)
+### 16.3. Author(s)
 This specification is created and maintained by Marko K. Seppänen.
 
 #### Creator
@@ -1691,7 +1743,7 @@ First authored in 2024, Gothenburg, by Marko K. Seppänen (Sweden via Finland).
 
 Mr. Seppänen has been programming since the mid-80s, working in languages like BASIC, C, Java, and Assembler. He studied Computer Science and Master's in Software Development with a focus on Programming Languages at Chalmers University of Technology (Gothenburg, Sweden). Professionally, he has many years of experience in software development, particularly in TypeScript, JavaScript, PHP, and full-stack web development.
 
-### 15.4. Spec Changes
+### 16.4. Spec Changes
 A running log of changes and updates **to this YINI specification**.
 
 Notes:
@@ -1705,7 +1757,7 @@ v1.0XX.0 Beta + Updates
 - Added table of all "Unicode Whitespace Characters" in <Unicode-WS>.
 - Added support for Triple-quoted strings with the prefix `C`, which interprets escape codes. Additionally, they can optionally be prefixed with `R` but this is not required since they are Raw by default.
 - Added "`base`"  as an alternative name for the implicit root section, in addition to the previously suggested "`root`".
-- Changed policy in 13.1, "Fallback Rules" to keep invalid key names or section headers as-is.
+- Changed policy in 14.1, "Fallback Rules" to keep invalid key names or section headers as-is.
 - Added note about optional "Abort Sensitivity Levels" in parsing.
 - Added a couple of sections in future:
   * 10.1.1, "Short-hand Section Marker"
@@ -1713,6 +1765,11 @@ v1.0XX.0 Beta + Updates
 - Updated section heading rule:
   * Section heading markers (^, ~, etc.) may be repeated up to six times to indicate levels 1–6. 
   * Beyond level 6, numeric shorthand must be used (see Section 5.3.1).
+- Added support for objects (`{ ... }`). 
+- Changed handling of trailing comma to:
+  - A missing value (empty value) for a **section-top-level** assignment in and that is not inside `[ ]` or `{ }`) is equivalent to `Null`.
+  - A missing **last element/member** inside `[ ... ]` or `{ ... }` is always considered a trailing comma and does not produce a null element.
+
 
 v1.0.0 Beta 6, 2025-05-20
 - Reworked the use of `#` **based on feedback**: it is no longer a section marker and is now used exclusively as a comment symbol (more in line with formats like classic INI, Bash, etc).
@@ -1720,13 +1777,13 @@ v1.0.0 Beta 6, 2025-05-20
   * This requirement prevents clashes with hex-like values. Using `#` for hex numbers (e.g., `#FF0033`) is a deliberate design choice and compromise to align with conventions found in CSS (for color) and similar contexts. For example: `#FF0033` is a hex value, whereas `# FF0033` is treated as a comment.
 - Due to the change where `#` is no longer used as a section marker, the tilde (`~`) was initially considered as the new default. However, multiple tildes on a line tend to visually blend together. In the end, the caret (`^`) was chosen instead for its clarity, visual distinctiveness, and compatibility with the 7-bit ASCII range.
 - Added support for full line comment using `;` and disable line using `--`.
-- Added section 15.6, "Appendix C – Common Mistakes and Pitfalls".
+- Added section 16.6, "Appendix C – Common Mistakes and Pitfalls".
   
 v1.0.0 Beta 5, 2025-05-13
-- Added new section 15.2, "Acknowledgments".
+- Added new section 16.2, "Acknowledgments".
 - Changed the default mode (after feedback of not requiring the /END) to non-stict (lenient) from Strict-mode:
   * Thus the "Document Terminator" is now only optional.
-  * Renamed section name to 11.3, "Lenient vs. Strict Modes".
+  * Renamed section name to 12.3, "Lenient vs. Strict Modes".
 - Added tab as illegal character in backticked identifiers.
 - Deprecated `>` for use as section marker, due to its tendency to be confused with quoting syntax in forums, emails, and messaging platforms, etc.
 - Added missing escape codes in strings (matching those from C/C++), with one exception: YINI uses `\OOO` instead of `\oOOO` for octal values, as the `o` clearly indicates that an octal sequence follows, whereas the C-style form does not.
@@ -1747,8 +1804,11 @@ v1.0.0 Beta 2, 2025-04-23
 
 ---
 
-### 15.6. Appendix C – Common Mistakes and Pitfalls
+### 16.6. Appendix C – Common Mistakes and Pitfalls
 Below are some common mistakes and misunderstandings when writing YINI files, especially for users familiar with other formats like YAML, JSON, or classic INI. This table aims to clarify syntax edge cases and help avoid subtle bugs.
+
+#### Trailing commas in list and objects
+Note: Trailing commas (after any value/member) inside list or objects, does never result in any `Null` values.
 
 ✅ YINI Syntax Cheatsheet – Common Confusions
 | **Element**       | **Correct Syntax**              | **Common Mistake**              | **Clarification** |
@@ -1757,8 +1817,8 @@ Below are some common mistakes and misunderstandings when writing YINI files, es
 | Inline List        | `items = ["a", "b", "c"]`       | `items =` followed by newline and `[` on next line | Line break after `=` causes the value to be parsed as null. |
 | Colon-Based List   | `items: "a", "b", "c"`          | `items: "a" "b" "c"`             | Items must be comma-separated — just like bracketed lists. |
 | Colon + Single Item| _Don't use_ `name: "John"`      | Same as left                    | Interpreted as a list with one string item — use `=` instead. |
-| Trailing comma (inline) | `list = ["a", "b", "c",]`   | Assumed to be ignored           | Adds a `null` item at the end of the list. |
-| Trailing comma (colon)  | `list:` <br> `"a", "b", "c",` | —                            | ✅ OK — trailing commas in colon-based lists are ignored. |
+| Trailing comma (inline) | `list = ["a", "b", "c",]`   | Empty value assumed to be null           | The comma is ignored, and does NOT add any `null` item at the end of the list. The result is same as: `list = ["a", "b", "c"]` |
+| Trailing comma (colon)  | `list:` <br> `"a", "b", "c",` | —                            | ✅ OK — trailing commas in colon-based lists, are ignored. |
 | Comments           | `# Comment` or `// Comment`     | `#Comment`                      | `#` must be followed by **space or tab** to be recognized as a comment. |
 | Hex values         | `color = #FF0033`               | Assumed to be a comment         | Without space after `#`, this is a valid hex value. |
 | Disable line       | `--key = "something"`           | Treated like a comment          | Entire line is ignored, including valid config syntax. |
@@ -1767,7 +1827,7 @@ Below are some common mistakes and misunderstandings when writing YINI files, es
 
 ---
 
-### 15.7. 🧾 Unicode Whitespace Characters
+### 16.7. 🧾 Unicode Whitespace Characters
 Below is a categorized list of Unicode whitespace characters recognized as within <Unicode-WS>, these are normalized or trimmed in Hyper Strings.
 
 | Code Point | Character Name                | Abbreviation | Unicode Category | Notes                                 |

--- a/YINI-Specification.md
+++ b/YINI-Specification.md
@@ -107,59 +107,63 @@ For more feedback details, see section D.2, _“Acknowledgments & Special Thanks
 &nbsp;&nbsp;&nbsp;&nbsp;8.1. Booleans  
 &nbsp;&nbsp;&nbsp;&nbsp;8.2. Null Literal
 
-**9. List Literals** ([Link ⇨](./YINI-Specification.md#9-list-literals))  
-&nbsp;&nbsp;&nbsp;&nbsp;9.1. Bracketed Lists (using `=`)  
-&nbsp;&nbsp;&nbsp;&nbsp;9.2. Colon-Based List (using `:`)
+**9. Object Literals** ([Link ⇨](./YINI-Specification.md#9-object-literals))  
+&nbsp;&nbsp;&nbsp;&nbsp;9.1. Objects (using `{` and `}`)  
 
-**10. Advanced Constructs** ([Link ⇨](./YINI-Specification.md#10-advanced-constructs))  
-&nbsp;&nbsp;&nbsp;&nbsp;10.1. Future / Reserved Features _(For Future Use)_  
+**10. List Literals** ([Link ⇨](./YINI-Specification.md#10-list-literals))  
+&nbsp;&nbsp;&nbsp;&nbsp;10.1. Bracketed Lists (using `=`)  
+&nbsp;&nbsp;&nbsp;&nbsp;10.2. Colon-Based List (using `:`)
+
+**11. Advanced Constructs** ([Link ⇨](./YINI-Specification.md#11-advanced-constructs))  
+&nbsp;&nbsp;&nbsp;&nbsp;11.1. Future / Reserved Features _(For Future Use)_  
 
 ---
 
 ### **Part III – Validation, Implementation & Compatibility**
 
-**11. Validation Rules** ([Link ⇨](./YINI-Specification.md#11-validation-rules))  
-&nbsp;&nbsp;&nbsp;&nbsp;11.1. Reserved Syntax  
-&nbsp;&nbsp;&nbsp;&nbsp;11.2. Well-Formedness Requirements  
-&nbsp;&nbsp;&nbsp;&nbsp;11.3. Lenient vs. Strict Modes _(Optional Feature)_  
+**12. Validation Rules** ([Link ⇨](./YINI-Specification.md#12-validation-rules))  
+&nbsp;&nbsp;&nbsp;&nbsp;12.1. Reserved Syntax  
+&nbsp;&nbsp;&nbsp;&nbsp;12.2. Well-Formedness Requirements  
+&nbsp;&nbsp;&nbsp;&nbsp;12.3. Lenient vs. Strict Modes _(Optional Feature)_  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;11.3.1. Table: Lenient vs. Strict Mode
 
-**12. Implementation Notes** ([Link ⇨](./YINI-Specification.md#12-implementation-notes))  
-&nbsp;&nbsp;&nbsp;&nbsp;12.1. Top-Level Sections and Implicit Root  
-&nbsp;&nbsp;&nbsp;&nbsp;12.2. Line Handling and Whitespace  
-&nbsp;&nbsp;&nbsp;&nbsp;12.3. Value and NULL Handling  
-&nbsp;&nbsp;&nbsp;&nbsp;12.4. Boolean Canonicalization  
-&nbsp;&nbsp;&nbsp;&nbsp;12.5. Lists  
-&nbsp;&nbsp;&nbsp;&nbsp;12.6. Strings Concatenation  
-&nbsp;&nbsp;&nbsp;&nbsp;12.7. String Literal Types  
-&nbsp;&nbsp;&nbsp;&nbsp;12.8. Comments  
-&nbsp;&nbsp;&nbsp;&nbsp;12.9. Error Handling Recommendations  
-&nbsp;&nbsp;&nbsp;&nbsp;12.10. Bonus Tips for Implementation
+**13. Implementation Notes** ([Link ⇨](./YINI-Specification.md#13-implementation-notes))  
+&nbsp;&nbsp;&nbsp;&nbsp;13.1. Top-Level Sections and Implicit Root  
+&nbsp;&nbsp;&nbsp;&nbsp;13.2. Line Handling and Whitespace  
+&nbsp;&nbsp;&nbsp;&nbsp;13.3. Value and NULL Handling  
+&nbsp;&nbsp;&nbsp;&nbsp;13.4. Boolean Canonicalization  
+&nbsp;&nbsp;&nbsp;&nbsp;13.5. Objects  
+&nbsp;&nbsp;&nbsp;&nbsp;13.5. Lists  
+&nbsp;&nbsp;&nbsp;&nbsp;13.6. Strings Concatenation  
+&nbsp;&nbsp;&nbsp;&nbsp;13.7. String Literal Types  
+&nbsp;&nbsp;&nbsp;&nbsp;13.8. Comments  
+&nbsp;&nbsp;&nbsp;&nbsp;13.9. Error Handling Recommendations  
+&nbsp;&nbsp;&nbsp;&nbsp;13.10. Bonus Tips for Implementation
 
-**13. Compatibility and Versioning** ([Link ⇨](./YINI-Specification.md#13-compatibility-and-versioning))  
-&nbsp;&nbsp;&nbsp;&nbsp;13.1. Fallback Rules  
-&nbsp;&nbsp;&nbsp;&nbsp;13.2. Versioning Strategy  
-&nbsp;&nbsp;&nbsp;&nbsp;13.3. Encoding Notes  
-&nbsp;&nbsp;&nbsp;&nbsp;13.4. JSON Compatibility
+**14. Compatibility and Versioning** ([Link ⇨](./YINI-Specification.md#14-compatibility-and-versioning))  
+&nbsp;&nbsp;&nbsp;&nbsp;14.1. Fallback Rules  
+&nbsp;&nbsp;&nbsp;&nbsp;14.2. Versioning Strategy  
+&nbsp;&nbsp;&nbsp;&nbsp;14.3. Encoding Notes  
+&nbsp;&nbsp;&nbsp;&nbsp;14.4. JSON Compatibility
 
 ---
 
 ### **Part IV – Examples and Appendices**
 
-**14. Examples** ([Link ⇨](./YINI-Specification.md#14-examples))  
-&nbsp;&nbsp;&nbsp;&nbsp;14.1. Minimal Example  
-&nbsp;&nbsp;&nbsp;&nbsp;14.2. Realistic Config Use Cases  
-&nbsp;&nbsp;&nbsp;&nbsp;14.3. Examples of YINI → JSON Mapping  
-&nbsp;&nbsp;&nbsp;&nbsp;14.4. Examples of JSON → YINI Mapping  
+**15. Examples** ([Link ⇨](./YINI-Specification.md#15-examples))  
+&nbsp;&nbsp;&nbsp;&nbsp;15.1. Minimal Example  
+&nbsp;&nbsp;&nbsp;&nbsp;15.2. Realistic Config Use Cases  
+&nbsp;&nbsp;&nbsp;&nbsp;15.3. Examples of YINI → JSON Mapping  
+&nbsp;&nbsp;&nbsp;&nbsp;15.4. Examples of JSON → YINI Mapping  
 
-**15. Appendices and Reserved Areas** ([Link ⇨](./YINI-Specification.md#15-appendices-and-reserved-areas))  
-&nbsp;&nbsp;&nbsp;&nbsp;15.1. License  
-&nbsp;&nbsp;&nbsp;&nbsp;15.2. Acknowledgments  
-&nbsp;&nbsp;&nbsp;&nbsp;15.3. Author(s)  
-&nbsp;&nbsp;&nbsp;&nbsp;15.4. Spec Changes  
-&nbsp;&nbsp;&nbsp;&nbsp;15.5. Reserved: Grammar (Formal)  
-&nbsp;&nbsp;&nbsp;&nbsp;15.6. Appendix C – Common Mistakes and Pitfalls  
-&nbsp;&nbsp;&nbsp;&nbsp;15.7. 🧾 Unicode Whitespace Characters  
+**16. Appendices and Reserved Areas** ([Link ⇨](./YINI-Specification.md#16-appendices-and-reserved-areas))  
+&nbsp;&nbsp;&nbsp;&nbsp;16.1. License  
+&nbsp;&nbsp;&nbsp;&nbsp;16.2. Acknowledgments  
+&nbsp;&nbsp;&nbsp;&nbsp;16.3. Author(s)  
+&nbsp;&nbsp;&nbsp;&nbsp;16.4. Spec Changes  
+&nbsp;&nbsp;&nbsp;&nbsp;16.5. Reserved: Grammar (Formal)  
+&nbsp;&nbsp;&nbsp;&nbsp;16.6. Appendix C – Common Mistakes and Pitfalls  
+&nbsp;&nbsp;&nbsp;&nbsp;16.7. 🧾 Unicode Whitespace Characters  
 
 ---
 
@@ -315,7 +319,7 @@ While YINI is not indentation-sensitive, the following whitespace `<WS>` behavio
 - Newlines (`<NL>`) may be either Unix/Linux-style (`LF`, U+000A), Windows-style (`CRLF`, U+000D U+000A), or (`CR`, U+000D).
 - Tabs (`<TAB>`, U+0009) and spaces (`<SPACE>`, U+0020) are ignored outside of strings and section headers.
 - Indentation using whitespace is allowed purely for visual clarity — it has no effect on parsing or structure.
-- Note: In the context of strings, the term `<Unicode-WS>` is used to refer to a broader range of Unicode whitespace characters, beyond just tab and space. For a complete table, see more in section 15.7, "🧾 Unicode Whitespace Characters".
+- Note: In the context of strings, the term `<Unicode-WS>` is used to refer to a broader range of Unicode whitespace characters, beyond just tab and space. For a complete table, see more in section 16.7, "🧾 Unicode Whitespace Characters".
 
 ### 3.3. Comments
 YINI supports **three types of comments**:
@@ -483,6 +487,7 @@ A YINI _**value**_ can be of one of the following three groups of native/built-i
   - Boolean
 
 - **Compound types:**
+  - Object (similar to a map) — a sequence of key-value pairs (members), separated by commas
   - List (also known as Arrays) — a sequence of values, separated by commas
 
 - **Special type:**
@@ -765,11 +770,11 @@ Like raw strings, Hyper Strings treat backslashes as literal characters — esca
 Hyper Strings are designed to be **multi-line friendly** and **visually readable**, especially for long text blocks:
 
 - `<NL>` refers to newline/linebreak of in combination of `CR`, `LF`, or `CRLF`.
-`<Unicode-WS>` includes all relevant Unicode whitespace characters: the categories `Zs` (space separators), `Zl` (line separators), `Zp` (paragraph separators), and selected `Cc` (control characters), primarily from the C0 range (`U+0000–U+001F`). For a complete table, see more in section 15.7, "🧾 Unicode Whitespace Characters".
+`<Unicode-WS>` includes all relevant Unicode whitespace characters: the categories `Zs` (space separators), `Zl` (line separators), `Zp` (paragraph separators), and selected `Cc` (control characters), primarily from the C0 range (`U+0000–U+001F`). For a complete table, see more in section 16.7, "🧾 Unicode Whitespace Characters".
 - Hyper Strings **can span multiple lines**, and indentation using `<Unicode-WS>` is allowed to improve human readability.
 - Multiple consecutive newlines (`<NL>`) and/or whitespace (`<Unicode-WS>`) are normalized into a **single space** (`U+0020`).
 - Leading and trailing `<NL>` and/or `<Unicode-WS>` are trimmed.
-- For the complete set of characters in <Unicode-WS>, refer to section 15.7 — [Unicode Whitespace Characters.](./YINI-Specification.md#157--unicode-whitespace-characters)
+- For the complete set of characters in <Unicode-WS>, refer to section 16.7 — [Unicode Whitespace Characters.](./YINI-Specification.md#157--unicode-whitespace-characters)
 
 Hyper Strings behave similarly to how text is rendered in HTML: extra spacing and line breaks are reduced to clean, flowing text.
 
@@ -917,7 +922,40 @@ Value/literal `NULL` (NON CASE-SENSITIVE).
 
 Also if value is missing in member, then that member is treated as NULL.
 
-## 9. List Literals
+## 9. Object Literals
+### 9.1. Objects (using `{` and `}`)
+YINI supports inline objects as a value type, allowing one or more key–value pairs to be nested inside braces `{` and `}`. An inline object behaves like a map or dictionary: each entry inside `{ ... }` is a standard YINI `key = value` pair, separated by commas. Objects may nest arbitrarily (an object value can itself contain another `{ ... }`).
+
+An object in YINI  have the following form:
+```txt
+<identifier> = { <key1> = <value1>, <key2> = <value2>, ... }
+```
+
+- The **key** in each member follows the same rules as any YINI identifier.
+The **value** in each member may be:
+  * A string (quoted with `'...'`).
+  * A number (integer or float).
+  * A boolean (true/false/on/off).
+  * A list (`[ ... ]`).
+  * Another inline object (`{ ... }`).
+
+The following rules apply to objects in YINI:
+- Begins with `{` and ends with `}`.
+- Between `{` and `}`, write one or more members of the form `key = value` (a member), separated by commas.
+- Optionally and only in lenient-mode, allow a trailing comma before the closing `}`
+- Whitespace (spaces, tabs, newlines) is ignored except inside quoted strings.
+- Comments (e.g. `// ...` or `# ...`) may appear anywhere whitespace is allowed.
+
+**Example:**
+```yini
+^ section
+object = { member1 = "value1", member2 = "value2" }
+```
+
+- 
+
+
+## 10. List Literals
 Lists in YINI correspond to what are called _Arrays_ in JSON and serve the same purpose as arrays in many programming languages (e.g., in JavaScript).
 
 YINI supports two ways to define lists:
@@ -926,7 +964,7 @@ YINI supports two ways to define lists:
 
 Note: Only lists can use the alternative notation using `:`.
 
-### 9.1. Bracketed Lists (using `=`)
+### 10.1. Bracketed Lists (using `=`)
 A list can be assigned to a key using the equals sign `=`, followed by square brackets `[ ]` containing zero or more comma-separated values.
 
 Whitespace (spaces, tabs, and newlines) is allowed within the brackets.
@@ -974,7 +1012,7 @@ linkItems = [
 ]
 ```
 
-### 9.2. Colon-Based List (using `:`)
+### 10.2. Colon-Based List (using `:`)
 Exclusively for lists, YINI allows an alternative syntax using a colon (`:`) instead of `=`. This style omits square brackets and is intended to improve readability in configurations with list-like values.
 
 Note: Commas are mandatory after items (except after the last item), even in multi-line forms in this notation.
@@ -1036,23 +1074,17 @@ linkItems:
 	["stylesheet", "css/themes.css"]
 ```
 
-## 10. Advanced Constructs
-### 10.1. Future / Reserved Features _(For Future Use)_
+## 11. Advanced Constructs
+### 11.1. Future / Reserved Features _(For Future Use)_
 The following features are reserved for potential support in future versions of the YINI specification. They are **not currently active** in this version, but their syntax and keywords **are reserved**.
 
-#### 10.1.1. Short-hand Section Marker
-Support for an alternative, shorter version of the section marker is planned to be added in the near future. 
-
-#### 10.1.2. Inline Objects
-Support for inline objects (e.g., within lists) is planned in the near future. 
-
-#### 10.1.3. Anchors and Aliases
+#### 11.1.1. Anchors and Aliases
 YINI may introduce a mechanism similar to YAML’s anchors and aliases. These constructs would allow users to define reusable fragments within a configuration.
 
   - **Anchors (`@`):** Or some other token, to assign a name to a key, section, or structure.
   - **Aliases (`use`):** Reference a previously defined anchor using the use keyword.
 
-#### 10.1.4. Includes
+#### 11.1.2. Includes
 YINI may support modular configuration files via external file inclusion.
   - **Directive:** `@include "<path/to/file>"`
   - **Description:** Imports the contents of another YINI file into the current one.
@@ -1060,19 +1092,19 @@ YINI may support modular configuration files via external file inclusion.
 
 These features, while not implemented in this version, are reserved and must not be repurposed by user-defined syntax.
 
-#### 10.1.5. Date-time Type
+#### 11.1.3. Date-time Type
 
 Currently, the YINI types in the specification map 1-to-1 to native JSON types. With that said YINI does not currently support native date, time, or date-time types. All date and time values **must currently** be represented as strings.
 
 Support for standardized date-time literals may be considered in a future version, once the core specification is stable.
 
-## 11. Validation Rules
+## 12. Validation Rules
 YINI enforces a set of validation rules to ensure the structure and content of files are consistent, unambiguous, and semantically correct. These rules fall into two main categories: **reserved syntax protections** and **well-formedness**. Validation ensures compatibility across implementations and minimizes user errors.
 
-### 11.1. Reserved Syntax
+### 12.1. Reserved Syntax
 Certain characters and keywords are **reserved** by the YINI specification for internal syntax or future use. Using them incorrectly may lead to a parse error or undefined behavior.
 
-#### 11.1.1. Reserved Characters
+#### 12.1.1. Reserved Characters
 The following characters are reserved by the YINI syntax and must not be used improperly outside of their defined contexts. They may appear inside quoted strings or phrase identifiers but are otherwise restricted:
 
 | Character	| Usage Context	| Description |
@@ -1092,7 +1124,7 @@ The following characters are reserved by the YINI syntax and must not be used im
 | `{ }` |  | Reserved for future syntax |
 | `--` | Line disabling | Experimental use (see Section 3.6) |
 
-#### 11.1.2. Reserved Keywords
+#### 12.1.2. Reserved Keywords
 The following keywords are restricted and must not be used as bare identifiers (e.g., for keys, values, or section names) unless enclosed in quotes or backticks:
 - `/END` _(case-insensitive)_
 - `@yini`
@@ -1101,7 +1133,7 @@ The following keywords are restricted and must not be used as bare identifiers (
 
 Use of these keywords outside their defined roles may result in a parse error.
 
-### 11.2. Well-Formedness Requirements
+### 12.2. Well-Formedness Requirements
 A YINI file is considered **well-formed** if it adheres to the core syntactic and structural rules defined in this specification.
 
 #### 11.2.1. Structural Requirements
@@ -1177,7 +1209,7 @@ The document terminator ensures robust parsing boundaries, improves multi-file s
     ```
     **Note:** Invalid: file contains only a comment and lacks both `/END` and title section.
 
-### 11.3. Lenient vs. Strict Modes _(Optional Feature)_
+### 12.3. Lenient vs. Strict Modes _(Optional Feature)_
 Non-strict mode (lenient mode) is the default and recommended mode of operation. Parsers should operate in this mode by default unless explicitly configured otherwise to operate in fully strict mode.
 
 Some YINI parsers may support multiple **validation modes**:
@@ -1200,7 +1232,7 @@ Some YINI parsers may support multiple **validation modes**:
 
 **Note:** Implementations must clearly document the validation mode in use and detail which rules are fully enforced under strict parsing.
 
-### 11.3.1. Table: Lenient vs. Strict Mode
+### 12.3.1. Table: Lenient vs. Strict Mode
 | Feature                 | Lenient Mode (Default) | Strict Mode | Notes |
 |-------------------------|:----------------------:|:-----------:|-------|
 | Explicit string quoting     | ✅ | ✅ | All strings must be enclosed with `"` or `'` — no ambiguity over strings.|
@@ -1213,13 +1245,13 @@ Some YINI parsers may support multiple **validation modes**:
 
 ⚠️ Strict mode enforces a stricter contract suitable for automated validation and reproducible builds. Lenient mode favors user-friendliness and flexibility for human editing.
 
-## 12. Implementation Notes
+## 13. Implementation Notes
 
 The following guidance is intended to assist developers implementing YINI parsers, engines, or tools. These notes aim to promote consistent interpretation of YINI syntax across different platforms and environments.
 
 See also [Section 11.2: Well-Formedness Requirements] for formal validation criteria.
 
-### 12.1. Top-Level Sections and Implicit Root
+### 13.1. Top-Level Sections and Implicit Root
 
 * If a document contains **multiple top-level sections** (i.e., multiple level-1 sections), they must be considered **children of an implicit root**.
 * The implicit root section:
@@ -1228,7 +1260,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   - A level-3 section **must follow** a level-2 section.
   - Skipping levels (e.g., directly from level-1 to level-3) is invalid.
 
-### 12.2. Line Handling and Whitespace
+### 13.2. Line Handling and Whitespace
 
 * Newline normalization is required:
   * Support all three forms: LF (`0x0A`), CRLF (`0x0D 0x0A`), and CR (`0x0D`.
@@ -1240,7 +1272,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
 * Full-line and inline comments may follow key-value members or appear on separate lines.
 * Whitespace is permitted within lists, including across lines.
 
-### 12.3. Value and NULL Handling
+### 13.3. Value and NULL Handling
 
 * If a key is assigned without a value::
   ```yini
@@ -1252,7 +1284,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   - Keys must be **unique within the same section and section level**.
   - Duplicates in the same section are a **parse error**.
 
-### 12.4. Boolean Canonicalization
+### 13.4. Boolean Canonicalization
 
 * Boolean literals are **case-insensitive**.
 * The following values must be interpreted as Booleans:
@@ -1260,7 +1292,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   * `false`, `no`, `off` → `false`
 * Do not allow Boolean values like `1` or `0` unless explicitly cast by the host software.
 
-### 12.5 Lists
+### 13.5 Lists
 
 * Two syntaxes are valid for lists:
   - **(a) Bracketed form (preferred):**
@@ -1286,7 +1318,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   [1, 2, 3]     // Not parsed as a list!
   ```
 
-### 12.6 Strings Concatenation
+### 13.6 Strings Concatenation
 
 * Strings can be concatenated using the `+` operator:
     ```yini
@@ -1296,7 +1328,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
 * Concatenating different types of strings (e.g., r"..." + c'...') is **permitted** (for use in some special or advanced cases), but generally **discouraged**.
 * Only Classic strings (C-Strings) interpret escape sequences (`\n`, `\t`, etc).
 
-### 12.7 String Literal Types
+### 13.7 String Literal Types
 **Note:** If a string is not quoted, it's not a string — period.
 
 | Type                   | Prefix           | Example    | Behavior |
@@ -1312,7 +1344,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   * Collapse sequences of whitespace and newlines into a single space.
   * Trim leading/trailing whitespace.
 
-### 12.8 Comments
+### 13.8 Comments
 
 * YINI supports:
   - `//` for inline comments (rest of the line is ignored).
@@ -1321,7 +1353,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   - `;`at start of line is treated as full-line comments (there may appear only spaces or tabs before `;`).
   - **Nested block comments are not supported.**
 
-### 12.9 Error Handling Recommendations
+### 13.9 Error Handling Recommendations
 
 If the parser encounters:
   * A **missing intermediate section level** (e.g., level 3 without level 2),
@@ -1332,7 +1364,7 @@ It should:
 * **Fail gracefully** and report an error, OR
 * **Use host-defined fallback logic**, if robustness is preferred.
 
-### 12.10 Bonus Tips for Implementation
+### 13.10 Bonus Tips for Implementation
 Developers are encouraged to implement the following features to improve parser robustness and developer experience:
 
 - Attach **position metadata** (line/column) to tokens for better diagnostics.
@@ -1347,18 +1379,18 @@ Developers are encouraged to implement the following features to improve parser 
   - Level 2 = abort even on warnings
 - **Extra Bonus:** In strings, if C/C++-style octal escape codes like `\1` to `\377` are used (which are not valid in YINI), parsers should treat this as an error in strict mode (and suggest the correct YINI syntax). In lenient mode, parsers may optionally emit a warning and suggest the correct YINI syntax: `\o1` to `\o377`, and interpret the octal code as intended.
 
-## 13. Compatibility and Versioning
+## 14. Compatibility and Versioning
 This section covers YINI's compatibility and interoperability principles.
 
-### 13.1. Fallback Rules
-#### 13.1.1. Invalid Sections or Keys
+### 14.1. Fallback Rules
+#### 14.1.1. Invalid Sections or Keys
 - Invalid key names or section headers **should be retained as-is** if possible and/or illegal characters remapped (both in lenient and strict mode, and optionally also support "Abort Sensitivity Levels"), though at least a warning should be issued depending on it's severity.
   
-#### 13.1.2. Graceful Degradation
+#### 14.1.2. Graceful Degradation
 - Parsers should issue warnings instead of errors when encountering unrecognized features (e.g., unknown directives, anchors, or section markers).
 - Implementations should strive to process known-valid content even if advanced features are not supported.
 
-### 13.2. Versioning Strategy
+### 14.2. Versioning Strategy
 **Version Format**
 
 - In the future, the YINI Specification will adopt _Semantic Versioning_ (`MAJOR.MINOR.PATCH STAGE`) to signal format evolution.
@@ -1369,24 +1401,24 @@ Semantic Versioning:
 - **MINOR:** Backward-compatible additions.
 - **PATCH:** Backward-compatible fixes.
 
-### 13.3. Encoding Notes
-#### 13.3.1 Required Encoding
+### 14.3. Encoding Notes
+#### 14.3.1 Required Encoding
 - **UTF-8 without BOM** is the required and default encoding for YINI files.
 - Parsers must support UTF-8 fully.
 - Use of other encodings (e.g., UTF-16, Latin-1) is discouraged and not guaranteed to be portable.
 
-#### 13.3.2 Byte Order Mark (BOM)
+#### 14.3.2 Byte Order Mark (BOM)
 - A UTF-8 BOM (`0xEF 0xBB 0xBF`) is **not required** and **should be avoided**.
 - If present, parsers must detect and ignore the BOM without failing.
 
-#### 13.3.3 Shebang Line (Optional)
+#### 14.3.3 Shebang Line (Optional)
 A shebang line may be used at the very top of the file:
 ```
 #!/usr/bin/env yini
 ```
 This line is ignored by YINI parsers but may affect script execution in Unix environments. It must be ignored by the YINI parser as a comment or metadata line.
 
-### 13.4. JSON Compatibility
+### 14.4. JSON Compatibility
 
 A valid YINI file can be converted into a valid JSON file (and vice versa) while preserving **data structure, types, and identifier names exactly**.
 
@@ -1423,9 +1455,9 @@ Conversely, a valid JSON object can be mapped into a YINI document, provided tha
 ### See also:
 See Sections 14.3 and 14.4 for examples of YINI ⇆ JSON mappings.
 
-## 14. Examples
+## 15. Examples
 
-### 14.1. Minimal Example
+### 15.1. Minimal Example
 ```yini
 ^ Prefs
 
@@ -1438,8 +1470,8 @@ enabled = true
   - Begins with a single section `# Prefs`.
   - Contains three keys (`name`, `entries`, `enabled`) with string, number, and boolean values, respectively.
 
-### 14.2. Realistic Config Use Cases
-#### 14.2.1. User Preferences Configuration
+### 15.2. Realistic Config Use Cases
+#### 15.2.1. User Preferences Configuration
 ```yini
 ^ Preferences
 
@@ -1454,7 +1486,7 @@ recent_files = [
 ]
 ```
 
-#### 14.2.2. Application Settings with Sections
+#### 15.2.2. Application Settings with Sections
 ```yini
 ^ Database
 host = "localhost"
@@ -1476,7 +1508,7 @@ api_version = "v2.1"
 **Notes:**
 - The `^` marker cleanly divides logical domains into sections.
 
-#### 14.2.3. Script Metadata
+#### 15.2.3. Script Metadata
 ```yini
 ^ Metadata
 name = "Data Fetch Script"
@@ -1486,7 +1518,7 @@ schedule = "daily"
 active = true
 ```
 
-#### 14.2.4. Feature Flags
+#### 15.2.4. Feature Flags
 ```yini
 ^ FeatureFlags
 debug = true
@@ -1496,7 +1528,7 @@ cache_expiry = 86400  		// In seconds
 last_purge_date = "2025-05-25"	// YYYY-MM-DD
 ```
 
-#### 14.2.5. Feature Toggles with Alternative Syntax
+#### 15.2.5. Feature Toggles with Alternative Syntax
 ```yini
 /*
   Feature Toggles with Alternative Syntax
@@ -1519,9 +1551,9 @@ last_purge_date = "2025-05-25"	// YYYY-MM-DD
 - \`Cache Config\` is a nested subsection of \`Feature Toggles\`.
 - All keys and section header identifiers are enclosed in backticks, allowing the use of spaces and special characters.
 
-### 14.3. Examples of YINI → JSON Mapping
+### 15.3. Examples of YINI → JSON Mapping
 
-#### 14.3.1. Simple Flat Structure to JSON
+#### 15.3.1. Simple Flat Structure to JSON
 **YINI:**
 ```yini
 ^ User
@@ -1541,7 +1573,7 @@ active = true
 }
 ```
 
-#### 14.3.2. Nested Sections (multiple levels) to JSON
+#### 15.3.2. Nested Sections (multiple levels) to JSON
 **YINI:**
 ```yini
 ^ Settings
@@ -1567,7 +1599,7 @@ language = "en"
 }
 ```
 
-#### 14.3.3. Lists (Arrays) to JSON
+#### 15.3.3. Lists (Arrays) to JSON
 **YINI:**
 ```yini
 ^ Server
@@ -1586,7 +1618,7 @@ hosts = ['server1.example.com', 'server2.example.com']
 }
 ```
 
-#### 14.3.4. Nulls and Booleans to JSON
+#### 15.3.4. Nulls and Booleans to JSON
 
 **Note:** Null and boolean literals (e.g., `Null`, `True`, `On`, `Yes`) in YINI are **case-insensitive**, while keys are **case-sensitive**.
 
@@ -1609,9 +1641,9 @@ description = Null
 }
 ```
 
-### 14.4. Examples of JSON → YINI Mapping
+### 15.4. Examples of JSON → YINI Mapping
 
-#### 14.4.1. Simple JSON Object to YINI
+#### 15.4.1. Simple JSON Object to YINI
 **JSON:**
 ```json
 {
@@ -1631,7 +1663,7 @@ age = 35
 verified = true
 ```
 
-#### 14.4.2. Nested JSON Objects to YINI
+#### 15.4.2. Nested JSON Objects to YINI
 **JSON:**
 ```json
 {
@@ -1655,7 +1687,7 @@ version = "2.5"
     notifications = true
 ```
 
-#### 14.4.3. JSON Array to YINI
+#### 15.4.3. JSON Array to YINI
 **JSON:**
 ```json
 {
@@ -1671,19 +1703,19 @@ version = "2.5"
 hosts = ["alpha.local", "beta.local", "gamma.local"]
 ```
 
-## 15. Appendices and Reserved Areas
-### 15.1. License
+## 16. Appendices and Reserved Areas
+### 16.1. License
 Apache License, Version 2.0, January 2004,
 http://www.apache.org/licenses/
 Copyright 2024-2025 Gothenburg, Marko K. Seppänen. (Sweden via
 Finland).
 
-### 15.2. Acknowledgments
+### 16.2. Acknowledgments
 _YINI would not exist in this form and shape what it is today, without the many insights, challenges, and thoughtful, constructive feedback from the community.
 
 For more details, see section D.2, _“Acknowledgments & Special Thanks”_, in the [Rationale](./RATIONALE.md) document.
 
-### 15.3. Author(s)
+### 16.3. Author(s)
 This specification is created and maintained by Marko K. Seppänen.
 
 #### Creator
@@ -1691,7 +1723,7 @@ First authored in 2024, Gothenburg, by Marko K. Seppänen (Sweden via Finland).
 
 Mr. Seppänen has been programming since the mid-80s, working in languages like BASIC, C, Java, and Assembler. He studied Computer Science and Master's in Software Development with a focus on Programming Languages at Chalmers University of Technology (Gothenburg, Sweden). Professionally, he has many years of experience in software development, particularly in TypeScript, JavaScript, PHP, and full-stack web development.
 
-### 15.4. Spec Changes
+### 16.4. Spec Changes
 A running log of changes and updates **to this YINI specification**.
 
 Notes:
@@ -1747,7 +1779,7 @@ v1.0.0 Beta 2, 2025-04-23
 
 ---
 
-### 15.6. Appendix C – Common Mistakes and Pitfalls
+### 16.6. Appendix C – Common Mistakes and Pitfalls
 Below are some common mistakes and misunderstandings when writing YINI files, especially for users familiar with other formats like YAML, JSON, or classic INI. This table aims to clarify syntax edge cases and help avoid subtle bugs.
 
 ✅ YINI Syntax Cheatsheet – Common Confusions
@@ -1767,7 +1799,7 @@ Below are some common mistakes and misunderstandings when writing YINI files, es
 
 ---
 
-### 15.7. 🧾 Unicode Whitespace Characters
+### 16.7. 🧾 Unicode Whitespace Characters
 Below is a categorized list of Unicode whitespace characters recognized as within <Unicode-WS>, these are normalized or trimmed in Hyper Strings.
 
 | Code Point | Character Name                | Abbreviation | Unicode Category | Notes                                 |

--- a/YINI-Specification.md
+++ b/YINI-Specification.md
@@ -738,9 +738,10 @@ Classic strings must begin and end on the same line.
 Escape sequences are supported only in Classic Strings (C-Strings), which must be enclosed in quotes and prefixed with `C` (or `c`). 
 
 **Full List: Escape Sequences: (case-sensitive, only valid in C-Strings and C-Triple-Quoted Strings)**
-- `\\` — backslash
+- `\\` — Backslash
 - `\'` — Single Quote
 - `\"` — Double Quote
+- `\/` — Normal Slash (yields a plain `/` as JSON)
 - `\0` — Null Byte
 - `\?` — Literal question mark (for C/C++ compatibility)
 - `\a` — Alert (bell)- ASCII 7
@@ -931,7 +932,7 @@ Value/literal `NULL` (NON CASE-SENSITIVE).
 ### 9.1. Objects (using `{` and `}`)
 YINI supports inline objects as a value type, allowing one or more key–value pairs to be nested inside braces `{` and `}`. An inline object behaves like a map or dictionary: each entry inside `{ ... }` is a standard YINI `key = value` pair, separated by commas. Objects may nest arbitrarily (an object value can itself contain another `{ ... }`).
 
-An empty object `{ }` is only allowed as in lenient-mode.
+An empty object `{ }` is allowed as well (both in lenient and strict-mode).
 
 An object in YINI  have the following form:
 ```txt
@@ -945,7 +946,7 @@ The **value** in each member may be:
   * A boolean (true/false/on/off).
   * A list (`[ ... ]`).
   * Another inline object (`{ ... }`).
-  * An empty object `{ }` is allowed as well only in lenient-mode.
+  * An empty object `{ }` is allowed as well (both in lenient/strict-mode).
 
 The following rules apply to objects in YINI:
 - Begins with `{` and ends with `}`.
@@ -1129,7 +1130,8 @@ The following characters are reserved by the YINI syntax and must not be used im
 | `//` | Inine comment |   |
 | `/* */` | Block comment | Marks multi-line comment block |
 | `@` | Directive prefix | Reserved for future syntax |
-| `{ }` |  | Reserved for future syntax |
+| `[ ]` | List literal |  |
+| `{ }` | Object literal |  |
 | `--` | Line disabling | Experimental use (see Section 3.6) |
 
 #### 12.1.2. Reserved Keywords
@@ -1287,15 +1289,15 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
 
 ### 13.3. Value and NULL Handling
 
-* If a key is assigned without a value::
+* If a key is assigned without a value (only in lenient-mode):
   ```yini
-  key =          // NULL
-  key:           // NULL
+  key =          // NULL, same as: key = Null
+  key:           // NULL, same as: key = [Null]
   ```
   it must be interpreted as having a value of `null`.
 * Key uniqueness:
   - Keys must be **unique within the same section and section level**.
-  - Duplicates in the same section are a **parse error**.
+  - Duplicates in the same section are a **parse warning**.
 
 ### 13.4. Boolean Canonicalization
 

--- a/YINI-Specification.md
+++ b/YINI-Specification.md
@@ -133,12 +133,12 @@ For more feedback details, see section D.2, _“Acknowledgments & Special Thanks
 &nbsp;&nbsp;&nbsp;&nbsp;13.3. Value and NULL Handling  
 &nbsp;&nbsp;&nbsp;&nbsp;13.4. Boolean Canonicalization  
 &nbsp;&nbsp;&nbsp;&nbsp;13.5. Objects  
-&nbsp;&nbsp;&nbsp;&nbsp;13.5. Lists  
-&nbsp;&nbsp;&nbsp;&nbsp;13.6. Strings Concatenation  
-&nbsp;&nbsp;&nbsp;&nbsp;13.7. String Literal Types  
-&nbsp;&nbsp;&nbsp;&nbsp;13.8. Comments  
-&nbsp;&nbsp;&nbsp;&nbsp;13.9. Error Handling Recommendations  
-&nbsp;&nbsp;&nbsp;&nbsp;13.10. Bonus Tips for Implementation
+&nbsp;&nbsp;&nbsp;&nbsp;13.6. Lists  
+&nbsp;&nbsp;&nbsp;&nbsp;13.7. Strings Concatenation  
+&nbsp;&nbsp;&nbsp;&nbsp;13.8. String Literal Types  
+&nbsp;&nbsp;&nbsp;&nbsp;13.9. Comments  
+&nbsp;&nbsp;&nbsp;&nbsp;13.10. Error Handling Recommendations  
+&nbsp;&nbsp;&nbsp;&nbsp;13.11. Bonus Tips for Implementation
 
 **14. Compatibility and Versioning** ([Link ⇨](./YINI-Specification.md#14-compatibility-and-versioning))  
 &nbsp;&nbsp;&nbsp;&nbsp;14.1. Fallback Rules  
@@ -924,7 +924,7 @@ Also if value is missing in member, then that member is treated as NULL.
 
 ## 9. Object Literals
 ### 9.1. Objects (using `{` and `}`)
-YINI supports inline objects as a value type, allowing one or more key–value pairs to be nested inside braces `{` and `}`. An inline object behaves like a map or dictionary: each entry inside `{ ... }` is a standard YINI `key = value` pair, separated by commas. Objects may nest arbitrarily (an object value can itself contain another `{ ... }`).
+YINI supports inline objects as a value type, allowing zero, one or more key–value pairs to be nested inside braces `{` and `}`. An inline object behaves like a map or dictionary: each entry inside `{ ... }` is a standard YINI `key = value` pair, separated by commas. Objects may nest arbitrarily (an object value can itself contain another `{ ... }`).
 
 An object in YINI  have the following form:
 ```txt
@@ -938,11 +938,12 @@ The **value** in each member may be:
   * A boolean (true/false/on/off).
   * A list (`[ ... ]`).
   * Another inline object (`{ ... }`).
+  * An empty object `{ }` is allowed as well only in lenient-mode.
 
 The following rules apply to objects in YINI:
 - Begins with `{` and ends with `}`.
 - Between `{` and `}`, write one or more members of the form `key = value` (a member), separated by commas.
-- Optionally and only in lenient-mode, allow a trailing comma before the closing `}`
+- Optionally and only in lenient-mode, after a value allow a trailing comma before the closing `}`
 - Whitespace (spaces, tabs, newlines) is ignored except inside quoted strings.
 - Comments (e.g. `// ...` or `# ...`) may appear anywhere whitespace is allowed.
 
@@ -1298,8 +1299,15 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   * `false`, `no`, `off` → `false`
 * Do not allow Boolean values like `1` or `0` unless explicitly cast by the host software.
 
-### 13.5 Lists
+### 13.5. Objects
+Any empty slot inside `{ ... }` e.g.:
+```
+object = { a = 1, , b = 2 }
+```
 
+is error in strict-mode or at least a warning (in lenient-mode).
+
+### 13.6. Lists
 * Two syntaxes are valid for lists:
   - **(a) Bracketed form (preferred):**
     ```yini
@@ -1324,7 +1332,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   [1, 2, 3]     // Not parsed as a list!
   ```
 
-### 13.6 Strings Concatenation
+### 13.7. Strings Concatenation
 
 * Strings can be concatenated using the `+` operator:
     ```yini
@@ -1334,7 +1342,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
 * Concatenating different types of strings (e.g., r"..." + c'...') is **permitted** (for use in some special or advanced cases), but generally **discouraged**.
 * Only Classic strings (C-Strings) interpret escape sequences (`\n`, `\t`, etc).
 
-### 13.7 String Literal Types
+### 13.8. String Literal Types
 **Note:** If a string is not quoted, it's not a string — period.
 
 | Type                   | Prefix           | Example    | Behavior |
@@ -1350,7 +1358,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   * Collapse sequences of whitespace and newlines into a single space.
   * Trim leading/trailing whitespace.
 
-### 13.8 Comments
+### 13.9. Comments
 
 * YINI supports:
   - `//` for inline comments (rest of the line is ignored).
@@ -1359,7 +1367,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
   - `;`at start of line is treated as full-line comments (there may appear only spaces or tabs before `;`).
   - **Nested block comments are not supported.**
 
-### 13.9 Error Handling Recommendations
+### 13.10. Error Handling Recommendations
 
 If the parser encounters:
   * A **missing intermediate section level** (e.g., level 3 without level 2),
@@ -1370,7 +1378,7 @@ It should:
 * **Fail gracefully** and report an error, OR
 * **Use host-defined fallback logic**, if robustness is preferred.
 
-### 13.10 Bonus Tips for Implementation
+### 13.11 Bonus Tips for Implementation
 Developers are encouraged to implement the following features to improve parser robustness and developer experience:
 
 - Attach **position metadata** (line/column) to tokens for better diagnostics.
@@ -1743,7 +1751,7 @@ v1.0XX.0 Beta + Updates
 - Added table of all "Unicode Whitespace Characters" in <Unicode-WS>.
 - Added support for Triple-quoted strings with the prefix `C`, which interprets escape codes. Additionally, they can optionally be prefixed with `R` but this is not required since they are Raw by default.
 - Added "`base`"  as an alternative name for the implicit root section, in addition to the previously suggested "`root`".
-- Changed policy in 13.1, "Fallback Rules" to keep invalid key names or section headers as-is.
+- Changed policy in 14.1, "Fallback Rules" to keep invalid key names or section headers as-is.
 - Added note about optional "Abort Sensitivity Levels" in parsing.
 - Added a couple of sections in future:
   * 10.1.1, "Short-hand Section Marker"
@@ -1763,13 +1771,13 @@ v1.0.0 Beta 6, 2025-05-20
   * This requirement prevents clashes with hex-like values. Using `#` for hex numbers (e.g., `#FF0033`) is a deliberate design choice and compromise to align with conventions found in CSS (for color) and similar contexts. For example: `#FF0033` is a hex value, whereas `# FF0033` is treated as a comment.
 - Due to the change where `#` is no longer used as a section marker, the tilde (`~`) was initially considered as the new default. However, multiple tildes on a line tend to visually blend together. In the end, the caret (`^`) was chosen instead for its clarity, visual distinctiveness, and compatibility with the 7-bit ASCII range.
 - Added support for full line comment using `;` and disable line using `--`.
-- Added section 15.6, "Appendix C – Common Mistakes and Pitfalls".
+- Added section 16.6, "Appendix C – Common Mistakes and Pitfalls".
   
 v1.0.0 Beta 5, 2025-05-13
-- Added new section 15.2, "Acknowledgments".
+- Added new section 16.2, "Acknowledgments".
 - Changed the default mode (after feedback of not requiring the /END) to non-stict (lenient) from Strict-mode:
   * Thus the "Document Terminator" is now only optional.
-  * Renamed section name to 11.3, "Lenient vs. Strict Modes".
+  * Renamed section name to 12.3, "Lenient vs. Strict Modes".
 - Added tab as illegal character in backticked identifiers.
 - Deprecated `>` for use as section marker, due to its tendency to be confused with quoting syntax in forums, emails, and messaging platforms, etc.
 - Added missing escape codes in strings (matching those from C/C++), with one exception: YINI uses `\OOO` instead of `\oOOO` for octal values, as the `o` clearly indicates that an octal sequence follows, whereas the C-style form does not.
@@ -1800,7 +1808,7 @@ Below are some common mistakes and misunderstandings when writing YINI files, es
 | Inline List        | `items = ["a", "b", "c"]`       | `items =` followed by newline and `[` on next line | Line break after `=` causes the value to be parsed as null. |
 | Colon-Based List   | `items: "a", "b", "c"`          | `items: "a" "b" "c"`             | Items must be comma-separated — just like bracketed lists. |
 | Colon + Single Item| _Don't use_ `name: "John"`      | Same as left                    | Interpreted as a list with one string item — use `=` instead. |
-| Trailing comma (inline) | `list = ["a", "b", "c",]`   | Assumed to be ignored           | Adds a `null` item at the end of the list. |
+| Trailing comma (inline) | `list = ["a", "b", "c",]`   | Empty value assumed to be null           | Does NOT add any `null` item at the end of the list. |
 | Trailing comma (colon)  | `list:` <br> `"a", "b", "c",` | —                            | ✅ OK — trailing commas in colon-based lists, are ignored. |
 | Comments           | `# Comment` or `// Comment`     | `#Comment`                      | `#` must be followed by **space or tab** to be recognized as a comment. |
 | Hex values         | `color = #FF0033`               | Assumed to be a comment         | Without space after `#`, this is a valid hex value. |

--- a/YINI-Specification.md
+++ b/YINI-Specification.md
@@ -403,7 +403,7 @@ An _**identifier**_ can be one of two forms below:
   `Amanda's Project`
   ```
 ### 3.5 Document Terminator
-**Note:** Below is only optional in lenient (non-strict) mode, which is the default.
+**Note:** The document terminator is only optional in lenient (non-strict) mode. Lenient mode is the default parser mode.
 
 A YINI document in strict mode **must always end with a terminator line**.
 
@@ -602,7 +602,7 @@ To place a section under another (i.e., to nest sections), repeat the section ma
 - Beyond level 6, the numeric shorthand section must be used (see section 5.3.1).
 - **Going deeper (increase nesting):** Must increment exactly one level at a time. E.g.: `^^` → `^^^` but not `^^` → `^^^^`.
 - **Going shallower (decrease nesting):** May drop directly to any previous level. E.g.: `^9` → `^^` or `^9` → `^`.
-- Optionally the short-hand section notation may be used for level 1 - 6 as well, but it's not preffered (e.g. `^^^` is `^3` interchangeable indeed).
+- Optionally the short-hand section notation may be used for any levels and that notation is the only way to define levels 7 or beyond.
 
 ```yini
 ^ Prefs
@@ -642,7 +642,7 @@ Optionally, indentation may be omitted:
 #### 5.3.1. Short-hand Section Heading
 
 **Short-hand Section Headings:**
-Numeric shorthand is required when nesting beyond six levels with the same marker (e.g., `^`). The syntax is `<marker><n>`, where `<marker>` is one of the allowed section marker characters (`^`, `~`, etc.) and `<n>` is an integer ≥ 6 indicating the nesting level (alternativily, integer ≥ 1 is allowed, but not recommended). For example:
+Numeric shorthand is required when nesting beyond six levels with the same marker (e.g., `^`). The syntax is `<marker><n>`, where `<marker>` is one of the allowed section marker characters (`^`, `~`, etc.) and `<n>` is an integer ≥ 1 indicating the nesting level (whilte the level is 1 - 6 the use of `^`, `^^`, `^^^` and so on is preferred). For example:
 
 - To go from depth 6 to depth 7: write `^7`.  
 - To go from depth 7 to depth 8: write `^8`.  
@@ -926,11 +926,34 @@ Value/literal `NULL` (NON CASE-SENSITIVE).
 
 - Empty or missing value in section-top-level key-value pair (member outside any list or object), is treated as NULL in lenient-mode, error in strict-mode.
   If written `key = `with nothing after `=`, that member’s value is `null` (lenient only; strict mode requires explicitly `key = null`).
-- Note: A missing value never produces a null value inside any list or object.
+- Note: At top level (outside any `[ ]` or `{ }`), `key =` with nothing after `=` → `key = null` in lenient mode; in strict mode that is a syntax error unless you write `key = null` explicitly.
+  Example:
+  ```yini
+  ^ Section
+  key = { a = } // NOT OK! Parse error on this row.
+  ```
+  ```yini
+  ^ Section
+  key = { a = Null } // OK
+  ```
+
+Example:
+```yini
+^ Section
+# In lenient-mode:
+key1 =       # lenient: key1 → null
+key2 = [1, 2, ]  # lenient: [1, 2, null]
+key3 = { a = 1, b = 2, }  # lenient: {a:1, b:2}
+
+# In Strict-mode:
+key1 =       # error: missing value
+key2 = [1, 2, ]  # error: trailing comma
+key3 = { a = 1, b = 2, }  # error: trailing comma
+```
 
 ## 9. Object Literals
 ### 9.1. Objects (using `{` and `}`)
-YINI supports inline objects as a value type, allowing one or more key–value pairs to be nested inside braces `{` and `}`. An inline object behaves like a map or dictionary: each entry inside `{ ... }` is a standard YINI `key = value` pair, separated by commas. Objects may nest arbitrarily (an object value can itself contain another `{ ... }`).
+YINI supports inline objects as a value type, allowing zero or more key–value pairs to be nested inside braces `{` and `}`. An inline object behaves like a map or dictionary: each entry inside `{ ... }` is a standard YINI `key = value` pair, separated by commas. Objects may nest arbitrarily (an object value can itself contain another `{ ... }`).
 
 An empty object `{ }` is allowed as well (both in lenient and strict-mode).
 
@@ -950,15 +973,34 @@ The **value** in each member may be:
 
 The following rules apply to objects in YINI:
 - Begins with `{` and ends with `}`.
-- Between `{` and `}`, write one or more members (also zero members is allowed in lenient-mode, while in strict-mode it must include at least one member) of the form `key = value` (a member), separated by commas.
+- Between `{` and `}`, write zero or more members (including no members at all is allowed both in lenient and strict mode) of the form `key = value` (a member), separated by commas.
 - Optionally and only in lenient-mode, after a value allow a trailing comma before the closing `}`
 - Whitespace (spaces, tabs, newlines) is ignored except inside quoted strings.
 - Comments (e.g. `// ...` or `# ...`) may appear anywhere whitespace is allowed.
+
+Grammar rule:
+```
+member-list := member ("," member)* ("," )?
+member      := IDENTIFIER "=" value
+```
 
 **Example:**
 ```yini
 ^ section
 object = { member1 = "value1", member2 = "value2" }
+```
+
+More Example:
+```
+# In lenient mode:
+obj1 = { a = 1, b = 2, }   # → {a:1, b:2} ✅
+obj2 = { a = 1,, b = 2 }   # → ❌ parse error or warning (double comma)
+obj3 = { , a = 1 }         # → ❌ parse error (leading comma not allowed)
+obj4 = { }                 # → {} ✅
+
+# In strict mode:
+obj1 = { a = 1, b = 2, }   # → ❌ error: trailing comma not allowed in strict mode
+obj4 = { }                 # → {} ✅
 ```
 
 ## 10. List Literals
@@ -1126,7 +1168,7 @@ The following characters are reserved by the YINI syntax and must not be used im
 | `;` | Full-line comment |   |
 | `:` | Alternative list notation | Outer list without brackets  |
 | `#` | Hexadecimal prefix | Begins hexadecimal number |
-| `# ` | Inline comment (alternative) | Comment, if starts with `#` followed by at least one space or tab |
+| `# ` | Inline comment (alternative) | Comment, if starts with `#` followed by at least one space or tab, due to `#` without space is reserved for hex literals (e.g. #FF00FF) |
 | `//` | Inine comment |   |
 | `/* */` | Block comment | Marks multi-line comment block |
 | `@` | Directive prefix | Reserved for future syntax |
@@ -1250,8 +1292,8 @@ Some YINI parsers may support multiple **validation modes**:
 |-------------------------|:----------------------:|:-----------:|-------|
 | Explicit string quoting               | ✅ | ✅ | All strings must be enclosed with `"` or `'` — no ambiguity over strings.|
 | Empty sections allowed                | ✅ | ✅ | Sections may contain no members (e.g., `^ Config`). |
-| Duplicate keys                        | ❌ | ❌ |   |
-| One level 1 section header            | ❌ | ✅ |   |
+| Duplicate keys or sections   | ❌ (may warn) | ❌ | And never overwrite existing keys/sections.  |
+| Required one single level-1 section header            | ❌ | ✅ | AKA _Title Section_.  |
 | `/END` required                       | ❌ | ✅ |   |
 | Trailing commas after value (inside lists/objects)| ✅ | ❌ | In lenient-mode the comma is ignored, error in strict-mode  |
 | Missing (empty) value (only in section-top-level)| ✅ | ❌ | Will result in a `Null` value in lenient-mode  |
@@ -1259,6 +1301,17 @@ Some YINI parsers may support multiple **validation modes**:
 | Invalid escape sequences              | ✅ (may warn) | ❌ (error) |   |
 
 ⚠️ Strict mode enforces a stricter contract suitable for automated validation and reproducible builds. Lenient mode favors user-friendliness and flexibility for human editing.
+
+Example:
+```yini
+# Lenient:
+key1 =         # → ✅ key1 = null
+key2 = ,       # → ❌ error: unexpected comma (may warn)
+
+# Strict:
+key1 =         # → ❌ error: missing value
+key2 = ,       # → ❌ error: unexpected comma
+```
 
 ## 13. Implementation Notes
 
@@ -1396,7 +1449,7 @@ Developers are encouraged to implement the following features to improve parser 
 - Support both `strict` as well as `lenient` parsing modes.
 - Support different **Abort Sensitivity Levels** while parsing a YINI document:
   (AKA severity threshold)
-  - Level 0 = ignore everything
+  - Level 0 = ignore errors and try parse anyway (may remap falty key/section names)
   - Level 1 = abort on errors only
   - Level 2 = abort even on warnings
 - **Extra Bonus:** In strings, if C/C++-style octal escape codes like `\1` to `\377` are used (which are not valid in YINI), parsers should treat this as an error in strict mode (and suggest the correct YINI syntax). In lenient mode, parsers may optionally emit a warning and suggest the correct YINI syntax: `\o1` to `\o377`, and interpret the octal code as intended.
@@ -1769,8 +1822,8 @@ v1.0XX.0 Beta + Updates
   * Beyond level 6, numeric shorthand must be used (see Section 5.3.1).
 - Added support for objects (`{ ... }`). 
 - Changed handling of trailing comma to:
-  - A missing value (empty value) for a **section-top-level** assignment in and that is not inside `[ ]` or `{ }`) is equivalent to `Null`.
-  - A missing **last element/member** inside `[ ... ]` or `{ ... }` is always considered a trailing comma and does not produce a null element.
+  - A missing value (empty value) for a **section-top-level** key-value assignment and that is not inside `[ ]` or `{ }`) is equivalent to `Null`.
+  - A missing **last element/member** inside `[ ... ]` or `{ ... }` is always considered a trailing comma and does not produce a null value/element (the comma is ignored).
 
 
 v1.0.0 Beta 6, 2025-05-20
@@ -1810,13 +1863,13 @@ v1.0.0 Beta 2, 2025-04-23
 Below are some common mistakes and misunderstandings when writing YINI files, especially for users familiar with other formats like YAML, JSON, or classic INI. This table aims to clarify syntax edge cases and help avoid subtle bugs.
 
 #### Trailing commas in list and objects
-Note: Trailing commas (after any value/member) inside list or objects, does never result in any `Null` values.
+Note: Trailing commas (after any value/member) inside list or objects, does never result in any `Null` values. Strict mode disallows a comma with no element after it altogether.
 
 ✅ YINI Syntax Cheatsheet – Common Confusions
 | **Element**       | **Correct Syntax**              | **Common Mistake**              | **Clarification** |
 |-------------------|----------------------------------|----------------------------------|--------------------|
 | Key–Value pair     | `name = "John"`                 | `name: "John"`                   | `:` creates a list — use `=` for single values. |
-| Inline List        | `items = ["a", "b", "c"]`       | `items =` followed by newline and `[` on next line | Line break after `=` causes the value to be parsed as null. |
+| Inline List        | `items = ["a", "b", "c"]`       | `items =` followed by newline and `[` on next line | Line break after `=` causes the value of `items` to be parsed as null. |
 | Colon-Based List   | `items: "a", "b", "c"`          | `items: "a" "b" "c"`             | Items must be comma-separated — just like bracketed lists. |
 | Colon + Single Item| _Don't use_ `name: "John"`      | Same as left                    | Interpreted as a list with one string item — use `=` instead. |
 | Trailing comma (inline) | `list = ["a", "b", "c",]`   | Empty value assumed to be null           | The comma is ignored, and does NOT add any `null` item at the end of the list. The result is same as: `list = ["a", "b", "c"]` |

--- a/YINI-Specification.md
+++ b/YINI-Specification.md
@@ -596,10 +596,13 @@ That is, the following denote nesting levels 1–6:
 To represent nesting deeper than level 6, switch to the **numeric shorthand section header** syntax (see Section 5.3.1).
 
 ### 5.3. Nested Sections
-To place a section under another (i.e., to nest sections), repeat the section marker character (this technique with repeating characters is inspired by Markdown) without skipping any intermediate levels. Each additional repetition indicates one more nesting level. However, when moving to a less‐nested (shallower) level, you may drop directly to any smaller level.
+To place a section under another (i.e., to nest sections), repeat the section marker character (this technique with repeating characters is inspired by Markdown) without skipping any intermediate levels. Each additional repetition indicates one more nesting level. However, when moving to a less‐nested (closer to section header) level, you may drop directly to any smaller level.
 
-- Section heading markers (`^` or `~`, etc) may only be repeated up to six times — to level 6.
+- Section heading markers (`^` or `~`, etc) may only be repeated up to six times — to level 6 (maximum).
 - Beyond level 6, the numeric shorthand section must be used (see section 5.3.1).
+- **Going deeper (increase nesting):** You must increment exactly one level at a time. E.g.: `^^` → `^^^` but not `^^` → `^^^^`.
+- **Going shallower (decrease nesting):** You may drop directly to any previous level. E.g.: `^9` → `^^` or `^9` → `^`.
+- Optionally the short-hand section notation may be used for level 1 - 6 as well, but it's not preffered (e.g. `^^^` is `^3` interchangeable indeed).
 
 ```yini
 ^ Prefs
@@ -639,7 +642,7 @@ Optionally, indentation may be omitted:
 #### 5.3.1. Short-hand Section Heading
 
 **Short-hand Section Headings:**
-Numeric shorthand is required when nesting beyond six levels with the same marker (e.g., `^`). The syntax is `<marker><n>`, where `<marker>` is one of the allowed section marker characters (`^`, `~`, etc.) and `<n>` is an integer ≥ 1 indicating the nesting level. For example:
+Numeric shorthand is required when nesting beyond six levels with the same marker (e.g., `^`). The syntax is `<marker><n>`, where `<marker>` is one of the allowed section marker characters (`^`, `~`, etc.) and `<n>` is an integer ≥ 6 indicating the nesting level (alternativily, integer ≥ 1 is allowed, but not recommended). For example:
 
 - To go from depth 6 to depth 7: write `^7`.  
 - To go from depth 7 to depth 8: write `^8`.  
@@ -920,7 +923,8 @@ The engine should convert the literal value to the corresponding Boolean value i
 ### 8.2. Null Literal
 Value/literal `NULL` (NON CASE-SENSITIVE). 
 
-Also if value is missing in member, then that member is treated as NULL.
+- Empty value in section-top-level key-value pair (member), that member is treated as NULL in lenient-mode, error in strict-mode.
+- Inside lists and objects, may contain a trailing comma efter the last value, that comma is ignored. A missing value never produces a null value in list or objects.
 
 ## 9. Object Literals
 ### 9.1. Objects (using `{` and `}`)
@@ -942,7 +946,7 @@ The **value** in each member may be:
 
 The following rules apply to objects in YINI:
 - Begins with `{` and ends with `}`.
-- Between `{` and `}`, write one or more members of the form `key = value` (a member), separated by commas.
+- Between `{` and `}`, write one or more members (also zero members is allowed in lenient-mode, while in strict-mode it must include at least one member) of the form `key = value` (a member), separated by commas.
 - Optionally and only in lenient-mode, after a value allow a trailing comma before the closing `}`
 - Whitespace (spaces, tabs, newlines) is ignored except inside quoted strings.
 - Comments (e.g. `// ...` or `# ...`) may appear anywhere whitespace is allowed.
@@ -952,9 +956,6 @@ The following rules apply to objects in YINI:
 ^ section
 object = { member1 = "value1", member2 = "value2" }
 ```
-
-- 
-
 
 ## 10. List Literals
 Lists in YINI correspond to what are called _Arrays_ in JSON and serve the same purpose as arrays in many programming languages (e.g., in JavaScript).
@@ -1038,11 +1039,11 @@ list1:
 list2:
   "oranges",
   "bananas",
-  "peaches",  // Trailing comma is valid here, and is ignored.
+  "peaches",  // Trailing comma is valid here, and is ignored. (Only in lenient-mode.)
 ```
 **Note:** This colon-based list syntax is only valid for lists.
 It must not be used for single values or key-value assignments.
-The trailing comma is ignored ONLY in `:` based lists.
+The trailing comma is ignored in lists ONLY in lenient-mode.
 
 ⚠️ **Common Pitfall**
 ```yini
@@ -1219,12 +1220,12 @@ Non-strict mode (lenient mode) is the default and recommended mode of operation.
 Some YINI parsers may support multiple **validation modes**:
 
 - **Lenient Mode:** 
-  - Permissive with minor errors (e.g., trailing commas (are ignored), mixed line endings).
+  - Permissive with minor errors (e.g., trailing commas after last value/member (are ignored), mixed line endings).
   - The document terminator (`/END`) is **optional** in lenient mode and may be omitted entirely.
   - All typing rules still apply — for example, string literals must be quoted: if a value is not quoted, it is not a string — no exceptions.
-  - Empty values are allowed:
-    - Empty value (after a comma) inside lists and object - is itnored.
-    - Empty value (ONLY outside lists and objects) are treated as `Null`.
+  - Empty values are allowed ONLY in members in section-top-levels:
+    - Missing value (ONLY outside lists and objects) are treated as `Null`.
+    - Trailing comma (after last value/member) inside lists and object - comma is ignored.
   - Useful for hand-edited configuration files.
 - **Strict Mode:**
   - Enforces full well-formedness.
@@ -1242,13 +1243,15 @@ Some YINI parsers may support multiple **validation modes**:
 ### 12.3.1. Table: Lenient vs. Strict Mode
 | Feature                 | Lenient Mode (Default) | Strict Mode | Notes |
 |-------------------------|:----------------------:|:-----------:|-------|
-| Explicit string quoting     | ✅ | ✅ | All strings must be enclosed with `"` or `'` — no ambiguity over strings.|
-| Empty sections allowed | ✅ | ✅ | Sections may contain no members (e.g., `^ Config`). |
-| Duplicate keys          | ❌ | ❌ |   |
-| One level 1 section header | ❌ | ✅ |   |
-| `/END` required         | ❌ | ✅ |   |
-| Trailing commas         | ✅ | ❌ |   |
-| Invalid escape sequences| ✅ (may warn) | ❌ (error) |   |
+| Explicit string quoting               | ✅ | ✅ | All strings must be enclosed with `"` or `'` — no ambiguity over strings.|
+| Empty sections allowed                | ✅ | ✅ | Sections may contain no members (e.g., `^ Config`). |
+| Duplicate keys                        | ❌ | ❌ |   |
+| One level 1 section header            | ❌ | ✅ |   |
+| `/END` required                       | ❌ | ✅ |   |
+| Trailing commas after value (inside lists/objects)| ✅ | ❌ | In lenient-mode the comma is ignored, error in strict-mode  |
+| Missing (empty) value (only in section-top-level)| ✅ | ❌ | Will result in a `Null` value in lenient-mode  |
+| Missing (empty) value before comma | - | ❌ | In lenient-mode must warn or make error  |
+| Invalid escape sequences              | ✅ (may warn) | ❌ (error) |   |
 
 ⚠️ Strict mode enforces a stricter contract suitable for automated validation and reproducible builds. Lenient mode favors user-friendliness and flexibility for human editing.
 
@@ -1801,6 +1804,9 @@ v1.0.0 Beta 2, 2025-04-23
 ### 16.6. Appendix C – Common Mistakes and Pitfalls
 Below are some common mistakes and misunderstandings when writing YINI files, especially for users familiar with other formats like YAML, JSON, or classic INI. This table aims to clarify syntax edge cases and help avoid subtle bugs.
 
+#### Trailing commas in list and objects
+Note: Trailing commas (after any value/member) inside list or objects, does never result in any `Null` values.
+
 ✅ YINI Syntax Cheatsheet – Common Confusions
 | **Element**       | **Correct Syntax**              | **Common Mistake**              | **Clarification** |
 |-------------------|----------------------------------|----------------------------------|--------------------|
@@ -1808,7 +1814,7 @@ Below are some common mistakes and misunderstandings when writing YINI files, es
 | Inline List        | `items = ["a", "b", "c"]`       | `items =` followed by newline and `[` on next line | Line break after `=` causes the value to be parsed as null. |
 | Colon-Based List   | `items: "a", "b", "c"`          | `items: "a" "b" "c"`             | Items must be comma-separated — just like bracketed lists. |
 | Colon + Single Item| _Don't use_ `name: "John"`      | Same as left                    | Interpreted as a list with one string item — use `=` instead. |
-| Trailing comma (inline) | `list = ["a", "b", "c",]`   | Empty value assumed to be null           | Does NOT add any `null` item at the end of the list. |
+| Trailing comma (inline) | `list = ["a", "b", "c",]`   | Empty value assumed to be null           | The comma is ignored, and does NOT add any `null` item at the end of the list. The result is same as: `list = ["a", "b", "c"]` |
 | Trailing comma (colon)  | `list:` <br> `"a", "b", "c",` | —                            | ✅ OK — trailing commas in colon-based lists, are ignored. |
 | Comments           | `# Comment` or `// Comment`     | `#Comment`                      | `#` must be followed by **space or tab** to be recognized as a comment. |
 | Hex values         | `color = #FF0033`               | Assumed to be a comment         | Without space after `#`, this is a valid hex value. |

--- a/YINI-Specification.md
+++ b/YINI-Specification.md
@@ -642,7 +642,7 @@ Optionally, indentation may be omitted:
 #### 5.3.1. Short-hand Section Heading
 
 **Short-hand Section Headings:**
-Numeric shorthand is required when nesting beyond six levels with the same marker (e.g., `^`). The syntax is `<marker><n>`, where `<marker>` is one of the allowed section marker characters (`^`, `~`, etc.) and `<n>` is an integer ≥ 1 indicating the nesting level (whilte the level is 1 - 6 the use of `^`, `^^`, `^^^` and so on is preferred). For example:
+Numeric shorthand is required when nesting beyond six levels with the same marker (e.g., `^`). The syntax is `<marker><n>`, where `<marker>` is one of the allowed section marker characters (`^`, `~`, etc.) and `<n>` is an integer ≥ 1 indicating the nesting level (while the level is 1 - 6 the use of `^`, `^^`, `^^^` and so on is preferred). For example:
 
 - To go from depth 6 to depth 7: write `^7`.  
 - To go from depth 7 to depth 8: write `^8`.  
@@ -980,7 +980,7 @@ The following rules apply to objects in YINI:
 
 Grammar rule:
 ```
-member-list := member ("," member)* ("," )?
+member-list := member ("," member)* ("," )?  // Any trailing is comma dropped.
 member      := IDENTIFIER "=" value
 ```
 

--- a/YINI-Specification.md
+++ b/YINI-Specification.md
@@ -975,7 +975,7 @@ list2 = [100, 200, 300]
 list3 = []  // An empty list.
 ```
 
-For convenience, a trailing comma (`,`) may be optionally be included.
+For convenience, a trailing comma (`,`) may be optionally be included (only in lenient-mode).
 
 ```yini
 // A list with THREE items.
@@ -1055,8 +1055,11 @@ name = "John"  // ✅ A single string value.
 **Colon (`:`) is not a substitute for `=`** and must not be used for regular member (non list) assignments.
 
 **Trailing Comma Behavior**
-- In colon-based lists, a **trailing comma is ignored** (legal, optional).
-- In bracketed lists (`[ ... ]`), a **trailing comma results in an implicit** `null` as the last item.
+- In objects, a **trailing comma is ignored** (legal in lenient-mode, optional).
+- In colon-based lists, a **trailing comma is ignored** (legal in lenient-mode, optional).
+- In bracketed lists (`[ ... ]`), a **trailing comma is ignored** (legal in 
+lenient-mode, optional).
+  
 
 **Termination Rule**
 
@@ -1215,9 +1218,12 @@ Non-strict mode (lenient mode) is the default and recommended mode of operation.
 Some YINI parsers may support multiple **validation modes**:
 
 - **Lenient Mode:** 
-  - Permissive with minor errors (e.g., trailing commas, mixed line endings).
+  - Permissive with minor errors (e.g., trailing commas (are ignored), mixed line endings).
   - The document terminator (`/END`) is **optional** in lenient mode and may be omitted entirely.
   - All typing rules still apply — for example, string literals must be quoted: if a value is not quoted, it is not a string — no exceptions.
+  - Empty values are allowed:
+    - Empty value (after a comma) inside lists and object - is itnored.
+    - Empty value (ONLY outside lists and objects) are treated as `Null`.
   - Useful for hand-edited configuration files.
 - **Strict Mode:**
   - Enforces full well-formedness.
@@ -1300,7 +1306,7 @@ See also [Section 11.2: Well-Formedness Requirements] for formal validation crit
     items = ["a", "b", "c"]
     ```
       * A bracketed list line must not begin with a comma.
-      * A trailing comma in `[ ]` is treated as a `null` value.
+      * A trailing comma in `[ ]` is ignored.
   - **(b) Unbracketed multiline:**
     ```yini
     items1: "a", "b", "c"
@@ -1745,6 +1751,11 @@ v1.0XX.0 Beta + Updates
 - Updated section heading rule:
   * Section heading markers (^, ~, etc.) may be repeated up to six times to indicate levels 1–6. 
   * Beyond level 6, numeric shorthand must be used (see Section 5.3.1).
+- Added support for objects (`{ ... }`). 
+- Changed handling of trailing comma to:
+  - A missing value (empty value) for a **section-top-level** assignment in and that is not inside `[ ]` or `{ }`) is equivalent to `Null`.
+  - A missing **last element/member** inside `[ ... ]` or `{ ... }` is always considered a trailing comma and does not produce a null element.
+
 
 v1.0.0 Beta 6, 2025-05-20
 - Reworked the use of `#` **based on feedback**: it is no longer a section marker and is now used exclusively as a comment symbol (more in line with formats like classic INI, Bash, etc).
@@ -1790,7 +1801,7 @@ Below are some common mistakes and misunderstandings when writing YINI files, es
 | Colon-Based List   | `items: "a", "b", "c"`          | `items: "a" "b" "c"`             | Items must be comma-separated — just like bracketed lists. |
 | Colon + Single Item| _Don't use_ `name: "John"`      | Same as left                    | Interpreted as a list with one string item — use `=` instead. |
 | Trailing comma (inline) | `list = ["a", "b", "c",]`   | Assumed to be ignored           | Adds a `null` item at the end of the list. |
-| Trailing comma (colon)  | `list:` <br> `"a", "b", "c",` | —                            | ✅ OK — trailing commas in colon-based lists are ignored. |
+| Trailing comma (colon)  | `list:` <br> `"a", "b", "c",` | —                            | ✅ OK — trailing commas in colon-based lists, are ignored. |
 | Comments           | `# Comment` or `// Comment`     | `#Comment`                      | `#` must be followed by **space or tab** to be recognized as a comment. |
 | Hex values         | `color = #FF0033`               | Assumed to be a comment         | Without space after `#`, this is a valid hex value. |
 | Disable line       | `--key = "something"`           | Treated like a comment          | Entire line is ignored, including valid config syntax. |


### PR DESCRIPTION
- Added support for objects (`{ ... }`). 
- Changed handling of trailing comma to:
  - A missing value (empty value) for a **section-top-level** assignment in and that is not inside `[ ]` or `{ }`) is equivalent to `Null`.
  - A missing **last element/member** inside `[ ... ]` or `{ ... }` is always considered a trailing comma and does not produce a null element.
