### PR TITLE
Refactored parser, so a new section is a member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ More details of feedback, see section D.2, _â€œAcknowledgments & Special Thanksâ
 - In spec, clarified "Abort Sensitivity Levels" and added it can also be called (or be known as) "Bail Sensitivity Levels".
 - In spec added section 2.4, "YINI Marker (`@yini`)" and support for it in the grammar (lexer and parser).
 - In lexer, fixed bug that caused DISABLE_LINE to skip/consume every line after the (`--`).
+- Refactored parser, so a new section is part of a "member" (instead of being a "nested section" part of a "section" directly). Due to it will be easier to implement the parser.
 
 ## 2025 Jun (spec: v1.0.0 Beta 7)
 - Fixed backticked identifiers (phrases) (as per Spec) cannot include tabs, newlines, or other backticks.

--- a/Grammar-ANTLR4/YiniParser.g4
+++ b/Grammar-ANTLR4/YiniParser.g4
@@ -29,7 +29,8 @@ yini:
 	YINI_MARKER? INLINE_COMMENT* NL* 
 	section+ NL* terminal_line? EOF?;
 
-section: SECTION_HEAD? section_members | SECTION_HEAD section?;
+//section: SECTION_HEAD? section_members | SECTION_HEAD section?;
+section: SECTION_HEAD? section_members;
 
 terminal_line: TERMINAL_TOKEN (NL+ | INLINE_COMMENT? NL*);
 
@@ -42,7 +43,8 @@ member:
 	//| KEY EQ NL+ // Empty value is treated as NULL.
 	KEY WS? EQ WS? value? NL+ // Empty value is treated as NULL.
 	//| KEY COLON elements? NL+
-	| member_colon_list;
+	| member_colon_list
+	| SECTION_HEAD section_members?;
 //| STRING COLON value? NL+; // ???
 
 member_colon_list: KEY COLON WS? elements? NL+;


### PR DESCRIPTION
Refactored parser, so a new section is a member (instead of a "nested" section with a section)

- Due to will be easier to implement the parser