### PR TITLE
Update - Require document terminator (/END) in strict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ More details of feedback, see section D.2, _â€œAcknowledgments & Special Thanksâ
   - See Section **15.7**.
   - The full YINI and JSON versions of these examples are also included under  
     [Large-Scale Real-World Configuration Examples](./Examples/Large-Scale%20Real-World%20Configuration%20Examples).
+- **Improved:** Cleaned up and reorganized the ANTLR4 lexer and parser grammar files (`.g4`) for better clarity, consistency, and maintainability.
   
 ## 2026 Mar (v1.0.0-rc.4)
 - **Removed:** In the Spec, support for colon-based list syntax (`key: value1, value2` and multi-line `key:` list form).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Edits and updates **in this repository**. (Very minor changes are not listed.)
 More details of feedback, see section D.2, _“Acknowledgments & Special Thanks”_, in the [Rationale](./RATIONALE.md) document.
 
 ## 2026 Mar + xxx (v1.0.0-rc.4 + UPDATES)
+- **Changed:** In the Spec, the document terminator (`/END`) is now required in strict mode and remains optional in lenient mode.
+- **Clarified:** In the Spec, updated the specification text, validation rules, and strict/lenient mode table to reflect that strict mode requires `/END` at the end of the document.
 - **Clarified:** In the Spec, repeated/basic section headers do not require a space before the section name, but numeric shorthand headers (such as `^7`) do.
 - **Clarified:** In the Spec, clarified top-level section rules in lenient and strict mode. Lenient mode allows orphan members at the root (or under implicit `base`), while strict mode requires exactly one top-level section.
 - **Updated:** In the Spec, added a third large real-world configuration example (C) for parsing in strict mode.

--- a/Grammar-ANTLR4/YiniLexer.g4
+++ b/Grammar-ANTLR4/YiniLexer.g4
@@ -9,12 +9,13 @@
 
 /* 
   This LEXER grammar aims to follow, as closely as possible (*),
-  the YINI format specification version:
+  the latest released version of the YINI format specification 1.0.0.
+  Version:
   1.2.0-rc.1x - 2026 Apr.
 
   *) NOTE: Some rules are intentionally more permissive than the specification
   requires. This relaxation allows the host parser to detect syntax errors
-  esier and provide clearer, more meaningful error messages. In the end, it is
+  easier and provide clearer, more meaningful error messages. In the end, it is
   the responsibility of the implementing parser to fully enforce all rules of
   the YINI specification.
 
@@ -31,61 +32,235 @@ lexer grammar YiniLexer;
   public atLineStart(): boolean { return this.column === 0; }
 }
 
-YINI_TOKEN options {
-	caseInsensitive = true;
-}: '@yini';
-
-// @note Experimental / for future / testing.
-INCLUDE_TOKEN options {
-	caseInsensitive = true;
-}: '@include';
-
-// @note Experimental / for future / testing.
-DEPRECATED_TOKEN options {
-	caseInsensitive = true;
-}: '@deprecated';
+/* ------------------------------------------------------------------
+ * Fragments
+ * ------------------------------------------------------------------ */
 
 fragment EBD: ('0' | '1') ('0' | '1') ('0' | '1');
+fragment HSPACE: [ \t];
+fragment DIGIT: [0-9];
+fragment SIGN: ('+' | '-');
 
-fragment HSPACE : [ \t];
+fragment IDENT_SIMPLE_START: [a-zA-Z_];
+fragment IDENT_SIMPLE_CHAR : [a-zA-Z0-9_];
 
-// SECTION_HEAD: SECTION_MARKER HSPACE* WS* IDENT NL+;
-SECTION_HEAD
-  // : SECTION_MARKER HSPACE+ SECTION_NAME_PART NL+ // Requires hor-WS between marker and name.
-  : SECTION_MARKER HSPACE* SECTION_NAME_PART NL+   // Does NOT require hor-WS between marker and name.
+fragment BIN_DIGIT: '0' | '1';
+fragment OCT_DIGIT: [0-7];
+fragment DUO_DIGIT: DIGIT | [xXeEaAbB]; // x = A = 10, e = B = 11.
+fragment HEX_DIGIT: DIGIT | [a-fA-F];
+
+fragment UNICODE16
+  : 'u' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
+  ;
+
+fragment UNICODE32
+  : 'U' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
+        HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
+  ;
+
+// Note: 0 or higher than 1, no leading 0s allowed (for ex: `01`)
+fragment DECIMAL_INTEGER
+  : '0'
+  | [1-9] DIGIT*
+  ;
+
+fragment INTEGER
+  : DECIMAL_INTEGER
+  ;
+
+fragment FRACTION
+  : '.' DIGIT+
+  ;
+
+fragment EXPONENT
+  : [eE] SIGN? DIGIT+
+  ;
+
+fragment BIN_INTEGER
+  : '0' [bB] BIN_DIGIT+
+  | '%' BIN_DIGIT+
+  ;
+
+fragment OCT_INTEGER
+  : '0' [oO] OCT_DIGIT+ // Make sure to not clash with boolean ON | OFF.
+  ;
+
+fragment DUO_INTEGER
+  : '0' [zZ] DUO_DIGIT+
+  ;
+
+fragment HEX_INTEGER
+  : '0' [xX] HEX_DIGIT+
+  | '#' HEX_DIGIT+
+  ;
+
+// NOTE: This lexer rule is intentionally relaxed to allow `.` as well.
+// This makes it possible for the parser (or later validation step) to detect
+// dotted compound names and report a more user-friendly error message, even
+// though such names are invalid in the YINI specification.
+//
+// IMPORTANT: The parser/validator must still check identifiers for illegal
+// characters and reject invalid dotted names accordingly.
+//
+// Examples of invalid dotted compound names:
+//     key.two
+//     main.`illegal key`
+//     another.key.2
+//     `yet another`.illegal.key
+fragment IDENT_SIMPLE_LX
+  : IDENT_SIMPLE_START (IDENT_SIMPLE_CHAR | '.')*
+  ;
+
+// IDENT_BACKTICKED: '`' ~[\u0000-\u001F`]* '`'; // No newlines, tabs, or C0 controls.
+fragment IDENT_BACKTICKED
+  : '`' ~[\u0000-\u001F`]* '`' // No newlines, tabs, or C0 controls.
+  ;
+
+fragment SECTION_NAME_PART
+  : IDENT_SIMPLE_LX
+  | IDENT_BACKTICKED
   ;
 
 // Section markers: '^', '<', '§'.
 // – Up to six repeated markers are allowed (the parser must enforce the ≤ 6 rule).
 // – For levels beyond 6, use the numeric shorthand form (e.g. ^7, <12, §100).
 fragment SECTION_MARKER
-    : SECTION_MARKER_BASIC_REPEAT // Classic/repeating marker section headers (e.g. ^^ SectionName).
-    | SECTION_MARKER_SHORTHAND // Numeric shorthand section headers (e.g. ^7 SectionName.
-	| SECTION_MARKER_INVALID // Catch invalid/errornous section markers, so it can be forwarded to the parser to show an error message.
-    ;
+  : SECTION_MARKER_BASIC_REPEAT      // Classic/repeating marker section headers (e.g. ^^ SectionName).
+  | SECTION_MARKER_SHORTHAND         // Numeric shorthand section headers (e.g. ^7 SectionName).
+  | SECTION_MARKER_INVALID           // Captures malformed section markers so the parser/validator can report a clearer error.
+  ;
 
-// Match one or more of the same marker.  Parser must check "count ≤ 6.",
-// this check is deferred to the parser, which
-// gives more control and enables better user feedback
+// Match one or more of the same marker. Parser must check "count ≤ 6".
+// This check is deferred to the parser, which
+// gives more control and enables better user feedback.
 fragment SECTION_MARKER_BASIC_REPEAT
-    : CARET+   // Up to 6 carets (implemented parser must reject more than 6)
-    | LT+      // Up to 6 LS characters
-    | SS+      // Up to 6 '§' characters
-    ;
+  : CARET+
+  | LT+
+  | SS+
+  ;
 
 // Shorthand: a single marker followed by a positive integer (1 or larger).
 // Examples: ^7, <12, §100
 fragment SECTION_MARKER_SHORTHAND
-    : (CARET | LT | SS) [1-9] DIGIT* HSPACE
-    ;
+  : (CARET | LT | SS) [1-9] DIGIT* HSPACE
+  ;
 
 fragment SECTION_MARKER_INVALID
-    : (CARET | LT | SS)+ DIGIT+
-    ;
+  : (CARET | LT | SS)+ DIGIT+
+  ;
 
-TERMINAL_TOKEN options {
-	caseInsensitive = true;
-}: '/END';
+// For matching bad character.
+fragment REST_CHAR
+  : ~([@ \t\r\n'"`=,0123456789/-] | '[' | ']' | '{' | '}' | ':')
+  ;
+
+/* ------------------------------------------------------------------
+ * Structural / directive tokens
+ * ------------------------------------------------------------------ */
+
+SHEBANG
+  : '#!' ~[\r\n]* EOL
+  ;
+
+YINI_TOKEN options { caseInsensitive = true; }
+  : '@yini'
+  ;
+
+// @note Experimental / for future / testing.
+INCLUDE_TOKEN options { caseInsensitive = true; }
+  : '@include'
+  ;
+
+// @note Experimental / for future / testing.
+DEPRECATED_TOKEN options { caseInsensitive = true; }
+  : '@deprecated'
+  ;
+
+TERMINAL_TOKEN options { caseInsensitive = true; }
+  : '/END'
+  ;
+
+// SECTION_HEAD: SECTION_MARKER HSPACE* WS* IDENT NL+;
+SECTION_HEAD
+  // : SECTION_MARKER HSPACE+ SECTION_NAME_PART NL+ // Requires hor-WS between marker and name.
+  // : SECTION_MARKER HSPACE* SECTION_NAME_PART NL+   // Repeated/basic section headers do not require whitespace before the name.
+  : SECTION_MARKER HSPACE* SECTION_NAME_PART HSPACE* EOL+ // Repeated/basic section headers do not require whitespace before the name.
+  ;
+
+INVALID_SECTION_HEAD
+  : (CARET | LT | SS)+ ~[\r\n]* EOL+
+  ;
+
+/* ------------------------------------------------------------------
+ * Keywords / literals
+ * ------------------------------------------------------------------ */
+
+BOOLEAN_FALSE options { caseInsensitive = true; }
+  : 'false' | 'off' | 'no'
+  ;
+
+BOOLEAN_TRUE options { caseInsensitive = true; }
+  : 'true' | 'on' | 'yes'
+  ;
+
+NULL options { caseInsensitive = true; }
+  : 'null'
+  ;
+
+EMPTY_OBJECT
+  : '{}'
+  ;
+
+EMPTY_LIST
+  : '[]'
+  ;
+
+STRING
+  : TRIPLE_QUOTED_STRING
+  | SINGLE_OR_DOUBLE
+  ;
+
+TRIPLE_QUOTED_STRING
+  : [RrCc]? '"""' .*? '"""'
+  ; // Greedy-safe because of .*? (non-greedy).
+
+SINGLE_OR_DOUBLE
+  : R_AND_C_STRING
+  | HYPER_STRING
+  ;
+
+/**
+ * Common rule for RAW and CLASSIC string literals.
+ * Illegal characters are deferred to the parser, which gives more control
+ * and enables better user feedback (e.g., pinpointing the exact location of
+ * invalid characters). Additionally, this simplifies the lexer rule.
+ *
+ * Rather than having the lexer reject on any "illegal" character, let the
+ * parser catch it so you can give a more precise error message.
+ *
+ * @note If refactoring rule(s), make sure C-strings can include \' and \" as well.
+ */
+R_AND_C_STRING
+  : [RrCc]? '\'' ('\\\'' | ~['\r\n])* '\''
+  | [RrCc]? '"'  ('\\"'  | ~["\r\n])* '"'
+  ;
+
+// Hyper string literal.
+HYPER_STRING
+  : [Hh] '\'' (~['])* '\''
+  | [Hh] '"'  (~["])* '"'
+  ;
+
+// NOTE: NUMBER must come before KEY, IDENT, etc.
+NUMBER
+  : SIGN? INTEGER FRACTION? EXPONENT?
+  | SIGN? FRACTION EXPONENT?
+  | SIGN? (BIN_INTEGER | OCT_INTEGER | DUO_INTEGER | HEX_INTEGER)
+  ;
+
+/* ------------------------------------------------------------------
+ * Punctuation / symbols
+ * ------------------------------------------------------------------ */
 
 SS: '\u00A7'; // Section sign §.
 CARET: '^';
@@ -107,156 +282,26 @@ PC: '%'; // PerCent sign.
 AT: '@';
 SEMICOLON: ';';
 
-BOOLEAN_FALSE options {
-	caseInsensitive = true;
-}: 'false' | 'off' | 'no';
+/* ------------------------------------------------------------------
+ * Line structure / skipped trivia
+ * ------------------------------------------------------------------ */
 
-BOOLEAN_TRUE options {
-	caseInsensitive = true;
-}: 'true' | 'on' | 'yes';
-
-NULL options {
-	caseInsensitive = true;
-}: 'null';
-
-EMPTY_OBJECT: '{}';
-EMPTY_LIST: '[]';
-
-SHEBANG: '#!' ~[\n\r\b\f\t]* NL;
-
-// NOTE: NUMBER must come before KEY, IDENT, etc.
-NUMBER:
-	SIGN? INTEGER ('.' DIGIT+)? EXPONENT?
-	| SIGN? '.' DIGIT+ EXPONENT?
-	| SIGN? (
-		BIN_INTEGER
-		| OCT_INTEGER // Make sure to not clash with boolean ON | OFF.
-		| DUO_INTEGER
-		| HEX_INTEGER
-	);
-
-// KEY: IDENT;
-KEY
-  : SECTION_NAME_PART
-  | IDENT_INVALID
+fragment EOL
+  : SECTION_TAIL_COMMENT* NL
   ;
 
-// fragment IDENT
-//   : IDENT_SIMPLE
-// 	| IDENT_BACKTICKED
-// 	| IDENT_INVALID;
-fragment SECTION_NAME_PART
-  : IDENT_SIMPLE_LX
-  | IDENT_BACKTICKED
+NL
+  : ('\r' '\n'? | '\n')+
   ;
 
-// fragment DOTTED_COMPOUND_NAME
-//   : (IDENT_SIMPLE | IDENT_BACKTICKED) ('.' (IDENT_SIMPLE | IDENT_BACKTICKED))+
-//   ;
+fragment SECTION_TAIL_COMMENT
+  : '//' ~[\r\n]*
+  | '#' HSPACE+ ~[\r\n]*
+  ;
 
-fragment IDENT_SIMPLE_START : [a-zA-Z_];
-fragment IDENT_SIMPLE_CHAR  : [a-zA-Z0-9_];
-
-// fragment IDENT_SIMPLE       : IDENT_SIMPLE_START IDENT_SIMPLE_CHAR*;
-
-// NOTE: This lexer rule is intentionally relaxed to allow `.` as well.
-// This makes it possible for the parser (or later validation step) to detect
-// dotted compound names and report a more user-friendly error message, even
-// though such names are invalid in the YINI specification.
-//
-// IMPORTANT: The parser/validator must still check identifiers for illegal
-// characters and reject invalid dotted names accordingly.
-//
-// Examples of invalid dotted compound names:
-//     key.two
-//     main.`illegal key`
-//     another.key.2
-//     `yet another`.illegal.key
-fragment IDENT_SIMPLE_LX       : IDENT_SIMPLE_START (IDENT_SIMPLE_CHAR | '.')*;
-
-// IDENT_BACKTICKED: '`' ~[\u0000-\u001F`]* '`'; // No newlines, tabs, or C0 controls.
-fragment IDENT_BACKTICKED: '`' ~[\u0000-\u001F`]* '`'; // No newlines, tabs, or C0 controls.
-
-// Illegal prefix characters and characters inside strings are deferred to the
-// parser, which gives more control and enables better user feedback (e.g.,
-// pinpointing the exact location of invalid characters, etc).
-
-STRING
-    : TRIPLE_QUOTED_STRING
-    | SINGLE_OR_DOUBLE
-    ;
-
-TRIPLE_QUOTED_STRING:
-	//'"""' (~["] | '"' ~["] | '""' ~["])* '"""';
-	[RrCc]? '"""' .*? '"""'
-	; // Greedy-safe because of .*? (non-greedy).
-
-SINGLE_OR_DOUBLE:
-	R_AND_C_STRING
-	| HYPER_STRING
-	;
-
-/**
- * Common rule for RAW and CLASSIC string literals.
- * Illegal characters are deferred to the parser, which gives more control
- * and enables better user feedback (e.g., pinpointing the exact location of
- * invalid characters). Additionally, this simplifies the lexer rule.
- *
- * Rather than having the lexer reject on any "illegal" character, lets the
- * parser catch it so you can give a more precise error message. 
- *
- * @note If refactoring rule(s), make sure C-strings can include \' and \" as well.
- */
-R_AND_C_STRING:
-	[RrCc]? '\'' 	('\\\'' | ~['\r\n])* '\''
-	| [RrCc]? '"'	('\\"' | ~["\r\n])* '"';
-
-
-// Hyper string literal.
-HYPER_STRING: [Hh] '\'' (~['])* '\''
-	| [Hh] '"' ( ~["])* '"';
-
-// Note: Like 8.2 in specification.
-ESC_SEQ: '\\' (["']) | ESC_SEQ_BASE;
-
-// Note: Except does'n not include quotes `"`, `'`.
-ESC_SEQ_BASE: '\\' ([\\0?abfnrtv] | UNICODE16 | UNICODE32);
-// TODO: Add support for \oOOO (up to 3 digits, valid range \o0 – \o377)
-
-fragment UNICODE16: 'u' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT;
-fragment UNICODE32:
-	'U' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT;
-
-fragment INTEGER: DECIMAL_INTEGER;
-
-// Note: 0 or higher than 1, no leading 0s allowed (for ex: `01`)
-fragment DECIMAL_INTEGER: '0' | SIGN? [1-9] DIGIT*;
-
-fragment BIN_INTEGER: ('0' ('b' | 'B') BIN_DIGIT+)
-	| ('%' BIN_DIGIT+);
-fragment OCT_INTEGER:
-	'0' ('o' | 'O') OCT_DIGIT+; // Make sure to not clash with boolean ON | OFF.
-fragment DUO_INTEGER: '0' ('z' | 'Z') DUO_DIGIT+;
-fragment HEX_INTEGER: ('0' ('x' | 'X') HEX_DIGIT+)
-	| ('#' HEX_DIGIT+);
-
-fragment DIGIT: [0-9];
-
-fragment BIN_DIGIT: '0' | '1';
-fragment OCT_DIGIT: [0-7];
-fragment DUO_DIGIT: DIGIT | [xeab] | [XEAB]; // x = A = 10, e = B = 11.
-fragment HEX_DIGIT: DIGIT | [a-f] | [A-F];
-
-fragment FRACTION: '.' DIGIT+;
-
-fragment EXPONENT: ('e' | 'E') SIGN? DIGIT+;
-
-fragment SIGN: ('+' | '-');
-
-NL: ( WS* COMMENT* SINGLE_NL COMMENT*);
-SINGLE_NL: ('\r' '\n'? | '\n');
-
-WS: HSPACE+ -> skip;
+WS
+  : HSPACE+ -> skip
+  ;
 
 /*
  BLOCK_COMMENT:
@@ -264,40 +309,51 @@ WS: HSPACE+ -> skip;
  Remains in input, but hidden
  (doesn't interfere with parsing).
  */
-BLOCK_COMMENT:
-	'/*' .*? '*/' -> skip; // Block AKA Multi-line comment.
-	
-COMMENT: LINE_COMMENT | INLINE_COMMENT | BLOCK_COMMENT;
+BLOCK_COMMENT
+  : '/*' .*? '*/' -> skip // Block AKA Multi-line comment.
+  ;
 
-fragment DISABLE_LINE_MARKER: '--';
+fragment DISABLE_LINE_MARKER
+  : '--'
+  ;
 
 /*
  FULL_LINE_COMMENT:
  Remains in input, but hidden
  (doesn't interfere with parsing).
  */
-//LINE_COMMENT: ((DISABLE_LINE|';') ~[\r\n]*) -> skip;
 LINE_COMMENT
   : {this.atLineStart()}? HSPACE* (DISABLE_LINE_MARKER | SEMICOLON) ~[\r\n]* -> skip
   ;
 
 /*
- INLINE_COMMENT: 
+ INLINE_COMMENT:
  Remains in input, but hidden (doesn't interfere with parsing).
  */
-INLINE_COMMENT: ('//' | '#' HSPACE+) ~[\r\n]* -> skip;
+INLINE_COMMENT
+  : ('//' | '#' HSPACE+) ~[\r\n]* -> skip
+  ;
+
+/* ------------------------------------------------------------------
+ * Identifiers / invalid / catch-all
+ * ------------------------------------------------------------------ */
+
+// KEY: IDENT;
+KEY
+  : SECTION_NAME_PART
+  | IDENT_INVALID
+  ;
 
 IDENT_INVALID
-    : [0-9][a-zA-Z0-9_]*
-    ;
+  : [0-9][a-zA-Z0-9_]*
+  ;
 
-// For matching bad character.
-fragment REST_CHAR:
-    ~([@ \t\r\n'"`=,0123456789/-] | '[' | ']' | '{' | '}' | ':')
-    ;
+// Catch-all for otherwise unclassified invalid content.
+REST
+  : REST_CHAR+
+  ;
 
-// For catching bad content.
-REST: REST_CHAR (REST_CHAR)*;
-
-// For catching bad meta commands.
-META_INVALID: AT WS? REST REST*;
+// Captures malformed @-prefixed directives/metadata.
+META_INVALID
+  : AT REST+
+  ;

--- a/Grammar-ANTLR4/YiniParser.g4
+++ b/Grammar-ANTLR4/YiniParser.g4
@@ -9,12 +9,13 @@
 
 /* 
   This PARSER grammar aims to follow, as closely as possible (*),
-  the YINI format specification version:
+  the latest released version of the YINI format specification 1.0.0.
+  Version:
   1.2.0-rc.1x - 2026 Apr.
 
   *) NOTE: Some rules are intentionally more permissive than the specification
   requires. This relaxation allows the host parser to detect syntax errors
-  esier and provide clearer, more meaningful error messages. In the end, it is
+  easier and provide clearer, more meaningful error messages. In the end, it is
   the responsibility of the implementing parser to fully enforce all rules of
   the YINI specification.
 
@@ -43,26 +44,34 @@ yini
   : prolog? stmt* terminal_stmt? EOF
   ;
 
-/* -------- Prolog / terminal_stmt -------- */
+/* ------------------------------------------------------------------
+ * Prolog / terminal
+ * ------------------------------------------------------------------ */
 
 prolog
-  : SHEBANG eol*       // shebang present
-  | eol+               // or at least one blank/comment line
+  : SHEBANG eol*
+  | eol+
   ;
 
 terminal_stmt
-  //: TERMINAL_TOKEN (eol | INLINE_COMMENT? NL*) // '/END' line, allow trailing comments/blank
-  : TERMINAL_TOKEN ( eol | INLINE_COMMENT )? NL*
+  : TERMINAL_TOKEN eol*
   ;
 
-/* -------- Statements (flat) -------- */
+/* ------------------------------------------------------------------
+ * Statements (flat)
+ * ------------------------------------------------------------------ */
 
 stmt
-  : eol				// BlankOrComment
-  | SECTION_HEAD	// SectionHeader
-  | assignment		// key = value
+  : eol             // BlankOrComment
+  | SECTION_HEAD    // SectionHeader
+  | invalid_section_stmt
+  | assignment      // key = value
   | meta_stmt       // Note: The implementing parser is responsible for enforcing YINI marker constraints.
   | bad_member      // BadMember
+  ;
+
+invalid_section_stmt
+  : INVALID_SECTION_HEAD
   ;
 
 // Any tokens and statements starting with an AT (@).
@@ -79,7 +88,7 @@ meta_stmt
  */
 directive
   : YINI_TOKEN eol
-  | INCLUDE_TOKEN WS* string_literal? eol
+  | INCLUDE_TOKEN string_literal? eol
   ;
 
 /*
@@ -87,7 +96,7 @@ directive
  * by including or transforming content before/while parsing.
  */
 // pre_processing_command
-//   : INCLUDE_TOKEN WS* string_literal? eol
+//   : INCLUDE_TOKEN string_literal? eol
 //   ;
 
 /*
@@ -101,13 +110,15 @@ annotation
   : DEPRECATED_TOKEN eol
   ;
 
-/* A single physical "end-of-line" unit (blank or comment then NL).
-   Use this everywhere instead of sprinkling NL* / INLINE_COMMENT* */
+/* A single physical "end-of-line" unit.
+   Use this everywhere instead of sprinkling NL* in statement rules. */
 eol
-  : INLINE_COMMENT? NL+
+  : NL+
   ;
 
-/* -------- Members / assignments -------- */
+/* ------------------------------------------------------------------
+ * Members / assignments
+ * ------------------------------------------------------------------ */
 
 /* Assignment is always: KEY = value/literal */
 assignment
@@ -116,13 +127,17 @@ assignment
 
 /* KEY = value  (value may be empty in lenient-mode -> NULL by convention,
  * enforced and validated in host code, not here.)
+ *
  * @note (!) KEY, EQ, and value MUST be on the same line!
  */
-member:
-  KEY WS? EQ WS? value? // Empty value is treated as NULL.
+member
+  : KEY EQ value? // Empty value is treated as NULL.
   ;
 
-/* -------- Values -------- */
+/* ------------------------------------------------------------------
+ * Values
+ * ------------------------------------------------------------------ */
+
 value
   : null_literal
   | string_literal
@@ -132,21 +147,21 @@ value
   | object_literal
   ;
 
-/* Object_literal is defined with object members such as { key: value, ... }
- * with optional trailing comma and newlines tolerated 
+/* Object literal is defined with object members such as { key: value, ... }
+ * with optional trailing comma and newlines tolerated.
  */
 object_literal
   : OC NL* object_members? NL* CC NL*
   | EMPTY_OBJECT NL*
   ;
 
-// A object_members is one or more key=value pairs separated by commas.
+// Object members are one or more key:value pairs separated by commas.
 object_members
   : object_member (COMMA NL* object_member)* COMMA?
   ;
 
 object_member
-  : KEY WS? COLON NL* value
+  : KEY COLON NL* value
   ;
 
 /* [ value, ... ] with optional trailing comma and newlines tolerated */
@@ -161,15 +176,35 @@ list_literal
 elements
   : value (NL* COMMA NL* value)* COMMA?
   ;
-  
 
-/* -------- Terminals forwarded from the lexer -------- */
+/* ------------------------------------------------------------------
+ * Terminals forwarded from the lexer
+ * ------------------------------------------------------------------ */
 
-number_literal   : NUMBER;
-null_literal     : NULL;							// NOTE: NULL is case-insensitive.
-string_literal   : STRING string_concat*;
-string_concat    : NL* PLUS NL* STRING;
-boolean_literal  : BOOLEAN_TRUE | BOOLEAN_FALSE;	// NOTE: Booleans are case-insensitive.
+number_literal
+  : NUMBER
+  ;
+
+null_literal
+  : NULL // NOTE: NULL is case-insensitive.
+  ;
+
+string_literal
+  : STRING string_concat*
+  ;
+
+string_concat
+  : NL* PLUS NL* STRING
+  ;
+
+boolean_literal
+  : BOOLEAN_TRUE
+  | BOOLEAN_FALSE // NOTE: Booleans are case-insensitive.
+  ;
+
+/* ------------------------------------------------------------------
+ * Error helpers
+ * ------------------------------------------------------------------ */
 
 bad_meta_text
   : META_INVALID
@@ -179,5 +214,5 @@ bad_meta_text
  * Keep a narrow error production, don't over-greedy-capture.
  */
 bad_member
-  : WS? (REST | value)? WS? EQ (value | REST) eol?
+  : (REST | value)? EQ (value | REST) eol?
   ;

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -71,7 +71,8 @@ The core motivations behind YINI include:
 - **Support for modern needs** — Structured sections, clear value types, multiline strings, inline comments, and formal grammar. (Note: while date/time objects are common in other formats, this is not yet addressed in YINI — it may be considered in future versions.)
 - **Predictability** — A small set of rules that always work the same way, regardless of platform or parser.
 - **Minimalist syntax** — Fewer surprises. YINI avoids magic behaviors and favors explicitness.
-
+- **Explicit completeness in strict mode** — In validation-oriented scenarios, relying on end-of-file alone can be too implicit. YINI strict mode uses a required `/END` terminator to make document completion explicit and easier to validate.
+- 
 ## B. Design Goals and Philosophy
 ### B.1. What inspired its design?
 YINI was mainly inspired by formats such as INI, JSON, Python, Markdown, and C — borrowing good ideas while introducing its own principles.
@@ -102,7 +103,7 @@ These values guide YINI's syntax, structure, and behavior — making it reliable
 - This is an intentional design decision to avoid ambiguity with hex-like values (e.g., CSS-style color codes), which are common in various domains.
 - Due to the change where `#` is no longer used as a section marker, the tilde (`~`) was initially considered as the new default. However, multiple tildes on a line tend to visually blend together. In the end, the caret (`^`) was chosen instead for its clarity, visual distinctiveness, and maximum compatibility (like `#` and `~`, it is also is within 7-bit ASCII).
 
-In v1.0.0 Alpha 8, the section marker character `~` (due to visually ambiguous) was replaced by `<`, which is also 7-bit ASCII.
+In v1.0.0 Alpha 8, the section marker character `~` was replaced by `<` because repeated tildes were judged visually ambiguous.
 
 #### B.2.2. Non-standard Octal Escape
 Octal escapes in YINI use the `\oNNN` format, which differs from the traditional `\NNN` style used in C and Python. 
@@ -119,11 +120,26 @@ This design choice was made because `\NNN` provides no clear indication of the n
 
 | Marker Char. | Status         | Example        | Notes |
 |--------------|---------------|---------------|---------|
-| `^`          | Official/main | `^^ Section2` | Always supported  |
-| `<`          | Alternative   | `<< Section2` | Easy to count, replaced `~` |
-| `§`          | Experimental  | `§§ Section2` | For enhanced readability, may be promoted in the future |
+| `^`          | Official/main | `^^ Section2` | Always supported (7-bit ASCII)  |
+| `<`          | Fallback   | `<< Section2` |  (7-bit ASCII) Easy to count, replaced `~` |
+| `§`          | Alternative  | `§§ Section2` | For enhanced readability, may be promoted in the future |
 | `~`          | Discontinued  | `~~ Section2` | Hard to count when repeated, phased out      |
 | `>`          | Discontinued  | `>> Section2` | Was easy to confuse with reply in forums, etc   |
+
+#### B.2.4. Why strict mode requires `/END`
+Strict mode in YINI is intended for cases where the parser should be strict on purpose — for example in validation-oriented (checking and verification) use cases, deterministic (predictable and consistent) parsing, safer tooling, CI pipelines, generated configuration, and other environments where ambiguity (uncertainty or unclear meaning) should be minimized.
+
+For that reason, strict mode requires the document terminator `/END`.
+
+With /END, the document does not just stop — it explicitly says that it is finished. This makes the end of the document clearer and reduces guesswork for both parsers and humans. The parser does not have to assume that the file ended correctly; instead, the document itself explicitly declares: “this document is complete.”
+
+This also makes it easier to detect documents that have been truncated, only partly copied, or cut off too early — including during transfer, file copy, manual copy-and-paste, embedding, or other situations where the content may end up incomplete.
+
+This works especially well together with strict mode's other structural rules, such as requiring exactly one explicit top-level section. Together, these rules improve robustness (reliability) and make strict mode better suited for validation-heavy (strictly checked) environments and safer tooling. If a strict-mode document is accidentally split, cut, or copied only in part, the resulting fragments are much more likely to be rejected as invalid rather than silently accepted as complete.
+
+This requirement was chosen not to make YINI more complicated in general, but to make strict mode more reliable, more predictable, and more trustworthy where correctness matters most.
+
+The other choice is to parse in lenient-mode, where the document terminator `/END` is not required.
 
 ## C. YINI vs Other Formats
 ### C.1. Why Not Existing Formats?
@@ -209,7 +225,7 @@ YINI is designed to be as simple and intuitive as possible. Its syntax aims to b
 
 Earlier drafts of YINI experimented with an alternative colon-based syntax for lists. While this shorthand could be convenient in some cases, it did not add any expressive capability beyond the standard bracketed list syntax.
 
-In practice, supporting colon-based lists introduced additional grammar rules, more edge cases, and a second mental model for representing the same data. This worked against several of YINI’s central design goals: clarity, predictability, minimalism, and a smaller, more consistent syntax surface.
+In practice, supporting colon-based lists introduced additional grammar rules, more edge cases, and a second mental model for representing the same data. This worked against several of YINI's central design goals: clarity, predictability, minimalism, and a smaller, more consistent syntax surface.
 
 By removing colon-based lists, YINI keeps a clearer and more uniform structure:
 - Values are assigned with `=`.
@@ -225,7 +241,7 @@ In future, MAYBE adding support for e.g.: `@yini strict`, `@yini version 1.0`, `
 
 #### Suggested terminology split in YINI spec
 
-Directives (pragmas): parser hints that affect mode/behavior but don’t change document content.
+Directives (pragmas): parser hints that affect mode/behavior but don't change document content.
 
 For example: `@yini strict`, `@mode lenient`, `@ver 1.0`, `@version 1.0`.
 

--- a/YINI-Specification.md
+++ b/YINI-Specification.md
@@ -209,8 +209,8 @@ The YINI format was created with the following key design goals in mind:
 
 - **Extensibility:** The format is designed to be extendable, allowing for future features and syntax to be incorporated as needed, such as support for anchors, includes, or custom validation rules.
 
-- **Deterministic parsing in strict mode:** Strict mode requires a single root section and prohibits ambiguous document endings.
-- 
+- **Deterministic parsing in strict mode:** Strict mode requires exactly one explicit top-level section and a terminating `/END`, reducing ambiguity around **truncated, partially copied, or otherwise incomplete documents.**
+  
 ### 1.3. Background and Intent
 YINI was created to serve as a clean, minimal, and predictable configuration format that balances readability with structure. For a deeper look into the motivation and design philosophy, see [Why YINI?](./RATIONALE.md).
 
@@ -230,7 +230,7 @@ YINI aims to prioritize **human readability, clarity, and clean syntax**.
 
 - **Multi-line and Nested Data:** The format supports multi-line strings and nested sections, providing the ability to express more complex configurations while maintaining readability.
 
-- **Clear End of Document:** YINI supports (optional in both lenient/strict-mode) a clear document terminator marker (`/END`).
+- **Clear End of Document:** YINI supports a clear document terminator marker (`/END`). It is optional in lenient mode and required in strict mode.
 
 ## 1.5. Terminology
 The following key terms are used consistently throughout this specification. Understanding these terms will help interpret YINI's grammar, structure, and semantics.
@@ -239,7 +239,7 @@ The following key terms are used consistently throughout this specification. Und
 |---------------------------|------------|
 | Classic String (C-String) | A string prefixed with `C` that supports escape sequences like `\n`, `\t`, etc. |
 | Configuration             | A structured set of members and sections that defines settings or data in a YINI document or file. |
-| Document Terminator       | A special line (`/END`) that explicitly marks the end of a YINI document (optional in both lenient/strict-mode). |
+| Document Terminator       | A special line (`/END`) that explicitly marks the end of a YINI document. It is optional in lenient mode and required in strict mode. |
 | Hyper String (H-String)    | A multi-line string prefixed with `H` that normalizes whitespace and trims edges. |
 | Identifier                | The name of a key or section. Can be a simple word (e.g., `title`) or a **backticked identifier** (wrapped in backticks). |
 | Key                       | An identifier on the left side of an assignment (`=`). Keys MUST be unique within their section (and depth/level). |
@@ -452,15 +452,13 @@ An _**identifier**_ can be one of two forms below:
   `Amanda's Project`
   ```
 ### 3.5 Document Terminator
-**Note:** The document terminator is only optional in lenient (non-strict) mode. Lenient mode is the default parser mode.
+**Note:** The document terminator is optional in lenient (non-strict) mode, which is the default parser mode. In strict mode, the document terminator is required.
 
-A YINI document **MAY end with a terminator line**.
+A YINI document MAY end with a terminator line in lenient mode. In strict mode, a YINI document MUST end with a terminator line.
 
-The document terminator explicitly marks the end of the configuration content and prevents ambiguity about whether the document was fully read.
+The document terminator explicitly marks the end of the configuration content and reduces ambiguity about whether the document was fully read. In strict mode, this makes document completion explicit rather than relying on end-of-file alone, **which helps detect truncated, partially copied, or prematurely cut-off documents.**
 
-In other words, it acts as a clear, unambiguous signal that the document is complete — without relying on end-of-file (EOF) and leaving parsers **to "guess" whether the final section or member was fully parsed**.
-
-The **default and recommended** terminator is:
+The default and recommended terminator is:
 ```yini
 /END
 ```
@@ -1227,7 +1225,7 @@ Note: In lenient mode, top-level members outside any section may be accepted. In
 - Duplicate keys **within the same section and depth level** are not allowed.
   - Keys are case-sensitive, and no spaces nor quotes allowed unless enclosed in backticks (phrase identifiers).
 - Lines that do not match any syntactic role (member, comment, section, terminator) are considered malformed.
-- The document terminator (`/END`) is **optional in both lenient/strict-mode**.
+- The document terminator (`/END`) is **optional in lenient mode and required in strict mode**.
 
 #### 12.2.2. Character Encoding
 Files **MUST** be encoded as **UTF-8 without BOM**.
@@ -1242,22 +1240,22 @@ Files **MUST** be encoded as **UTF-8 without BOM**.
 - Null values: `null`, `NULL`, `Null` are all interpreted as `null`.
 
 #### 12.2.5. Document Terminator
-- The terminator is optional in both lenient/strict-mode.
-- See Section 3.5, "Document Terminator" for terminator syntax.
-- A valid YINI file, MAY end with the terminator marker (`/END`).
+- In lenient mode, the terminator is optional.
+- In strict mode, the terminator is required.
+- See Section 3.5, "Document Terminator", for terminator syntax.
+- A valid YINI file in **strict mode** MUST end with the terminator marker (`/END`).
+- A valid YINI file in **lenient mode** MAY end with the terminator marker (`/END`).
 - Only one terminator is permitted per file.
 - Missing terminators:
-  - **In lenient mode:** No error or warning.
-  - **In strict mode:** Treated as an error.
+  * **In lenient mode:** No error is required.
+  * **In strict mode:** MUST be treated as an error.
 - After the terminator, only whitespaces and comments are allowed.
 
 ##### Table: Terminator Requirement by Mode
 | Mode | Terminator Requirement |
 |---|---|
-| Lenient | Optional (*) |
-| Strict  | Optional (*) |
-
-(*) In systems that value deterministic parsing, MAY favor explicit termination.
+| Lenient | Optional |
+| Strict  | Required |
 
 #### 12.2.6. Escaping and String Literals
 - Escape sequences are **ONLY allowed** in in C-Triple-quoted and Classic strings (quoted with `'` or `"`, **and prefixed** with `C` or `c`).
@@ -1265,14 +1263,15 @@ Files **MUST** be encoded as **UTF-8 without BOM**.
 
 #### 12.2.7. Shortest Valid YINI Documents in Strict Mode
 - **Valid short documents in strict mode:**
-  - ✅ In strict mode, the following is the shortest valid YINI document **with a member**:
+  - ✅ In strict mode, the following is the shortest valid YINI document in strict mode:
     ```yini
     ^T
+    /END
     ```
-    **Note:** A section heading named `T`, without any members.
+    **Note:** This document contains a single explicit top-level section named T and the required document terminator.
 
 - **Invalid short documents:**
-  - ❌  Invalid: no title section present:
+  - ❌  Invalid: no title section present in strict mode:
     ```yini
     /END
     ```
@@ -1284,7 +1283,7 @@ Some YINI parsers may support multiple **validation modes**:
 
 - **Lenient Mode:** 
   - Permissive with minor errors (e.g., trailing commas after last value/member (are ignored), mixed line endings).
-  - The document terminator (`/END`) is **optional** in both lenient and strict modes and MAY be omitted entirely.
+  - The document terminator (`/END`) is optional in lenient mode and MAY be omitted entirely.
   - All typing rules still apply — for example, string literals MUST be quoted: if a value is not quoted, it is not a string — no exceptions.
   - Empty values are allowed ONLY in members in section-top-levels:
     - Missing/empty value (ONLY outside lists and objects) are treated as `Null`.
@@ -1296,8 +1295,7 @@ Some YINI parsers may support multiple **validation modes**:
   - No (stray) trailing commas (after last value/member) inside lists and object permitted.
   - Strict mode requires exactly one explicit top-level section. Any additional sections MUST appear only as subsections nested within that section. Top-level orphan members are not allowed in strict mode. Otherwise, an error MUST be reported.  
     
-    If also using the OPTIONAL document terminator `/END` then these
-    constraints will provide increased robustness: if a YINI document is split into two halves, **both halves will be invalid**.
+    Because strict mode also requires the document terminator `/END`, the end of the document is made explicit rather than being inferred from EOF alone. This improves deterministic parsing, reduces ambiguity about incomplete input, and makes **truncated, partially copied, or prematurely cut-off documents** easier to detect. Together with the requirement for exactly one explicit top-level section, this provides increased robustness: if a YINI document is split into two halves, **both halves will be invalid**.  
     * The **first half** is invalid because it is missing the required `/END` marker.
     * The **second half** is invalid because it lacks the required single level 1 section header (e.g., `^ Title`).
   - Disallows trailing commas.
@@ -1329,7 +1327,7 @@ object3 = { a: 1, b: 2 }     # ✅ OK
 | Duplicate keys or sections   | ❌ (may warn) | ❌ | And never overwrite existing keys/sections.  |
 | Exactly one explicit top-level section required            | ❌ | ✅ | In strict mode, all other sections MUST be nested within it.  |
 | Top-level orphan members allowed | ✅ | ❌ | In lenient mode they may be mounted at root or under implicit base. |
-| `/END` is optional                       | ✅ | ✅ |   |
+| `/END` required at end of document                       | ❌ | ✅ |   |
 | Trailing commas after value (inside lists/objects)| ✅ | ❌ | In lenient-mode the comma is ignored, error in strict-mode  |
 | Missing (empty) value (only in section-top-level)| ✅ | ❌ | Will result in a `Null` value in lenient-mode  |
 | Missing (empty) value before comma | - | ❌ | In lenient-mode SHOULD warn or make error  |
@@ -1569,7 +1567,7 @@ Conversely, a valid JSON object can be mapped into a YINI document, provided tha
 | Key/Value Syntax    | ✅ Top-level: `key = value`<br>Object: `key: value`| ✅ Keys always quoted, `:` for objects| YINI uses `=` for top-level, `:` for object members.                              |
 | Identifiers (Keys)  | ✅ Unquoted, or backticked if needed               | ✅ Must always be quoted              | Backticks in YINI for special chars; JSON always quotes keys.                     |
 | Comments            | ✅ Supported (full-line, inline, or multi-line)                 | 🚫 Not supported (discarded)          | Comments are dropped when converting to JSON.                                     |
-| Terminator          | ✅ Optional (for doc-ending)                       | 🚫 Not supported (ignored)            | YINI document terminator (`/END`) is ignored in JSON.                              |
+| Terminator          | ✅ Supported in YINI (`/END`)                       | 🚫 Not supported in JSON            | YINI's document terminator has no JSON equivalent and is ignored when converting to JSON.                              |
 
 ### See also:
 See Sections 14.3 and 14.4 for examples of YINI ⇆ JSON mappings.
@@ -2480,6 +2478,8 @@ Notes:
 - All dates in international format, YYYY-MM-DD.
 
 v1.0.0 RC 4 + UPDATES, 2026-04-07 + xxx
+- **Changed:** The document terminator (`/END`) is now required in strict mode and remains optional in lenient mode.
+- **Clarified:** Updated the specification text, validation rules, and strict/lenient mode table to reflect that strict mode requires `/END` at the end of the document.
 - **Clarified:** Clarified whitespace rules for section headers: repeated/basic section headers do not require a space before the section name, while numeric shorthand headers (such as `^7`) do.
 - **Clarified:** Defined top-level structure rules for lenient and strict mode. In lenient mode, orphan members may be exposed at the root or under an implicit base section; in strict mode, exactly one explicit top-level section is allowed, all additional sections MUST be nested beneath it, and top-level orphan members are forbidden.
 - **Updated:** Added a third large real-world configuration example (C) for parsing in strict mode.
@@ -2502,7 +2502,8 @@ v1.0.0 RC 4, 2026-03-29
 - **Fixed:** Fixed a few typos and made various minor wording and consistency improvements.
 
 v1.0.0 RC 3, 2025-09-01
-- The specification has been revised to clarify that the document terminator `/END` is no longer a mandatory requirement in strict mode. The terminator is now defined as optional in both lenient and strict parsing modes. Implementing parsers MAY optionally provide an option to require this in both lenient and strict mode.
+- Changed at that time: The document terminator `/END` was made optional in both lenient and strict mode.
+- Note: This was later revised again in v1.0.0 RC 4 + UPDATES, where `/END` became required in strict mode.
 
 v1.0.0 RC 2, 2025-08-11
 - Added case-insensitive support for digits `A` (10) and `B` (11) as alternative syntax in duodecimal (base-12) notation.


### PR DESCRIPTION
- Update the specification and rationale to make the `/END` terminator mandatory in strict mode while remaining optional in lenient mode.
- Clarify how this requirement improves robustness by helping detect truncated or incomplete documents.
- Refresh validation rules, mode comparison tables, and examples to reflect the change.
- Clarified, cleaned up the readme a bit.
- Cleaned up lexer and parser .g4-files.