### PR TITLE
Make grammar target-independent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # CHANGELOG
+
 Edits and updates **in this repository and package**. (Very minor changes are not listed.)
 
 ### Feedback Acknowledgments
+
 More details of feedback, see section D.2, _“Acknowledgments & Special Thanks”_, in the [Rationale](./RATIONALE.md) document.
 
+## 2026 xxx (v1.0.0-rc.5 + UPDATES)
+- Updated the lexer grammar to be target-independent by removing TypeScript-specific members and semantic predicates, enabling cross-language parser generation.
+  
 ## 2026 Apr (v1.0.0-rc.5)
 - **Changed:** In the Spec, the document terminator (`/END`) is now required in strict mode and remains optional in lenient mode.
 - **Clarified:** In the Spec, updated the specification text, validation rules, and strict/lenient mode table to reflect that strict mode requires `/END` at the end of the document.

--- a/Grammar-ANTLR4/YiniLexer.g4
+++ b/Grammar-ANTLR4/YiniLexer.g4
@@ -11,7 +11,7 @@
   This LEXER grammar aims to follow, as closely as possible (*),
   the latest released version of the YINI format specification 1.0.0.
   Version:
-  1.2.0-rc.2 - 2026 Apr (v1.0.0-rc.5 YINI Spec Package).
+  1.2.0-rc.2 + UPDATES - 2026 Apr (v1.0.0-rc.5 YINI Spec Package).
 
   *) NOTE: Some rules are intentionally more permissive than the specification
   requires. This relaxation allows the host parser to detect syntax errors
@@ -26,11 +26,6 @@
 */
 
 lexer grammar YiniLexer;
-
-@members {
-  // Below is TypeScript code:
-  public atLineStart(): boolean { return this.column === 0; }
-}
 
 /* ------------------------------------------------------------------
  * Fragments
@@ -319,11 +314,14 @@ fragment DISABLE_LINE_MARKER
 
 /*
  FULL_LINE_COMMENT:
- Remains in input, but hidden
- (doesn't interfere with parsing).
- */
-LINE_COMMENT
-  : {this.atLineStart()}? HSPACE* (DISABLE_LINE_MARKER | SEMICOLON) ~[\r\n]* -> skip
+ This rule intentionally does not enforce "start of line" in the lexer.
+ The parser or later validation step must verify that FULL_LINE_COMMENT appears
+ only where a full-line comment is allowed.
+*/
+// todo: if it doesn't work, try delete skip
+FULL_LINE_COMMENT
+  : HSPACE* (DISABLE_LINE_MARKER | SEMICOLON) ~[\r\n]* -> skip
+  //: ('\r\n' | '\r' | '\n') HSPACE* (DISABLE_LINE_MARKER | SEMICOLON) ~[\r\n]* -> skip
   ;
 
 /*

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 ![Status: Release Candidate](https://img.shields.io/badge/status-rc-blueviolet)
 
-**Package Version:** 1.0.0-RC.5 ([Version Mapping Table](./README.md#version-mapping-table))  
+**Package Version:** 1.0.0-RC.5 + UPDATES ([Version Mapping Table](./README.md#version-mapping-table))  
 **Date:** 2026-04  
 **Status:** Release Candidate  
 


### PR DESCRIPTION
Removed TypeScript-specific members and semantic predicates from the lexer grammar to allow for cross-language parser generation. Updated versioning in the README and CHANGELOG to reflect these updates.